### PR TITLE
move install_certs into main role

### DIFF
--- a/roles/demo_certs/tasks/main.yml
+++ b/roles/demo_certs/tasks/main.yml
@@ -17,10 +17,3 @@
   ansible.builtin.include_tasks: issue-certs.yml
   when:
     - create_demo_certs | default(false) | bool
-
-# Copies certs that follow this directory structure into their respective node
-# tls/certs/{{ansible_hostname}}/node.crt
-- name: Install certs
-  ansible.builtin.include_tasks: install-certs.yml
-  when:
-    - handle_cert_install | default(false) | bool

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -24,3 +24,7 @@ redpanda_key_file: "{{ redpanda_certs_dir }}/node.key"
 redpanda_cert_file: "{{ redpanda_certs_dir }}/node.crt"
 redpanda_truststore_file: "{{ redpanda_certs_dir }}/truststore.pem"
 node_exporter_version: "{{ node_exporter_custom_version | default('1.5.0') }}"
+
+# copied into the nodes as part of tls
+ca_cert_file: "tls/ca/ca.crt"
+node_cert_file: "tls/certs/{{ansible_hostname}}/node.crt"

--- a/roles/redpanda_broker/tasks/install-certs.yml
+++ b/roles/redpanda_broker/tasks/install-certs.yml
@@ -3,7 +3,7 @@
   tags:
     - install_certs
   ansible.builtin.copy:
-    src: "{{ ca_crt_file }}"
+    src: "{{ ca_cert_file }}"
     dest: "{{ redpanda_truststore_file }}"
     owner: redpanda
     group: redpanda

--- a/roles/redpanda_broker/tasks/install-certs.yml
+++ b/roles/redpanda_broker/tasks/install-certs.yml
@@ -3,7 +3,7 @@
   tags:
     - install_certs
   ansible.builtin.copy:
-    src: tls/ca/ca.crt
+    src: "{{ ca_crt_file }}"
     dest: "{{ redpanda_truststore_file }}"
     owner: redpanda
     group: redpanda
@@ -14,7 +14,7 @@
   tags:
     - install_certs
   ansible.builtin.copy:
-    src: tls/certs/{{ansible_hostname}}/node.crt
+    src: "{{ node_cert_file }}"
     dest: "{{ redpanda_cert_file }}"
     owner: redpanda
     group: redpanda

--- a/roles/redpanda_broker/tasks/main.yml
+++ b/roles/redpanda_broker/tasks/main.yml
@@ -10,6 +10,13 @@
   when:
     - prep_data_dir | default(true) | bool
 
+# Copies certs set in ca_cert_file and node_cert_file into the redpanda nodes. see defaults for the default values
+# only necessary when TLS is enabled
+- name: Install certs
+  ansible.builtin.include_tasks: install-certs.yml
+  when:
+    - handle_cert_install | default(false) | bool
+
 - name: Install Redpanda
   ansible.builtin.include_tasks: install-redpanda.yml
 


### PR DESCRIPTION
Install certs fit awkwardly into the demo certs role because you need to be able to install certs when running TLS. This commit moves them into the main role.

This change will also ensure that the end user is able to set custom certs in the playbook, giving them greater flexibility.