### PR TITLE
fail if no version is provided

### DIFF
--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -23,7 +23,3 @@ redpanda_key_file: "{{ redpanda_certs_dir }}/node.key"
 redpanda_cert_file: "{{ redpanda_certs_dir }}/node.crt"
 redpanda_truststore_file: "{{ redpanda_certs_dir }}/truststore.pem"
 node_exporter_version: "{{ node_exporter_custom_version | default('1.5.0') }}"
-
-# copied into the nodes as part of tls
-ca_cert_file: "tls/ca/ca.crt"
-node_cert_file: "tls/certs/{{ansible_hostname}}/node.crt"

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -12,7 +12,6 @@ redpanda_use_staging_repo: false
 redpanda_repo_debian: "{{ 'https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.deb.sh' if not redpanda_use_staging_repo|bool else 'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.deb.sh' }}"
 redpanda_repo_redhat: "{{ 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' if not redpanda_use_staging_repo|bool else 'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.rpm.sh' }}"
 redpanda_repo_script: "{{ redpanda_repo_debian if ansible_os_family == 'Debian' else redpanda_repo_redhat }}"
-redpanda_version: latest # For example 22.2.2-1 or 22.3.1~rc1-1. If this value is set then the package will be upgraded if the installed version is lower than what has been specified.
 redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
 redpanda_rpk_opts: ""
 

--- a/roles/redpanda_broker/tasks/main.yml
+++ b/roles/redpanda_broker/tasks/main.yml
@@ -4,6 +4,20 @@
     msg: "A valid value must be provided for redpanda_version ex: '22.2.2-1' or 'latest'"
   when: redpanda_version is not defined
 
+- name: Check if ca_cert_file is defined
+  fail:
+    msg: "A valid path must be provided for ca_cert_file ex: tls/certs/ca.crt"
+  when:
+    - handle_cert_install | default(false) | bool
+    - ca_cert_file is not defined
+
+- name: Check if node_cert_file is defined
+  fail:
+    msg: "A valid path must be provided for node_cert_file ex: tls/certs/node.crt"
+  when:
+    - handle_cert_install | default(false) | bool
+    - node_cert_file is not defined
+
 # installs necessary dependencies for running redpanda
 - name: Install dependencies
   ansible.builtin.include_tasks: install-node-deps.yml

--- a/roles/redpanda_broker/tasks/main.yml
+++ b/roles/redpanda_broker/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if redpanda_version is defined
+  fail:
+    msg: "A valid value must be provided for redpanda_version ex: '22.2.2-1' or 'latest'"
+  when: redpanda_version is not defined
+
 # installs necessary dependencies for running redpanda
 - name: Install dependencies
   ansible.builtin.include_tasks: install-node-deps.yml


### PR DESCRIPTION
Users should provide a specific version, although if they choose to use latest that's fine too.