### PR TITLE
remove install script and use json

### DIFF
--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -32,6 +32,7 @@ rp_conf_loc_rpm: "/etc/yum.repos.d/redpanda-redpanda.repo"
 rp_key_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
 rp_config_url_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/config.deb.txt"
 rp_conf_loc_deb: "/etc/apt/sources.list.d/redpanda.list"
+rp_key_path_deb: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg"
 rpm_prerequisite_packages:
   - curl
   - yum-utils

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -26,3 +26,17 @@ node_exporter_version: "{{ node_exporter_custom_version | default('1.5.0') }}"
 cloud_storage_credentials_source: "config_file"
 cloud_storage_enable_remote_write: "true"
 cloud_storage_enable_remote_read: "true"
+rp_key_rpm: "https://dl.redpanda.com/public/redpanda/gpg.988A7B0A4918BC85.key"
+rp_config_url_rpm: "https://dl.redpanda.com/public/redpanda/config.rpm.txt"
+rp_key_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
+rp_config_url_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/config.deb.txt"
+rpm_prerequisite_packages:
+  - curl
+  - yum-utils
+  - dnf-plugins-core
+debian_prerequisite_packages:
+  - debian-keyring
+  - debian-archive-keyring
+  - apt-transport-https
+  - ca-certificates
+  - gnupg

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 redpanda_organization: redpanda-test
 redpanda_cluster_id: redpanda
 
@@ -9,13 +8,14 @@ redpanda_kafka_port: 9092
 redpanda_rpc_port: 33145
 
 redpanda_use_staging_repo: false
-redpanda_repo_debian: "{{ 'https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.deb.sh' if not redpanda_use_staging_repo|bool else 'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.deb.sh' }}"
-redpanda_repo_redhat: "{{ 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' if not redpanda_use_staging_repo|bool else 'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.rpm.sh' }}"
-redpanda_repo_script: "{{ redpanda_repo_debian if ansible_os_family == 'Debian' else redpanda_repo_redhat }}"
+redpanda_base_url: "https://dl.redpanda.com"
+
 redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
 redpanda_rpk_opts: ""
 
-redpanda_data_directory: /var/lib/redpanda/data
+redpanda_base_dir: /var/lib/redpanda
+redpanda_data_directory: "{{ redpanda_base_dir }}/data"
+repdanda_mount_dir: /mnt/vectorized/redpanda
 
 redpanda_certs_dir: /etc/redpanda/certs
 redpanda_csr_file: "{{ redpanda_certs_dir }}/node.csr"
@@ -26,13 +26,13 @@ node_exporter_version: "{{ node_exporter_custom_version | default('1.5.0') }}"
 cloud_storage_credentials_source: "config_file"
 cloud_storage_enable_remote_write: "true"
 cloud_storage_enable_remote_read: "true"
-rp_key_rpm: "https://dl.redpanda.com/public/redpanda/gpg.988A7B0A4918BC85.key"
-rp_config_url_rpm: "https://dl.redpanda.com/public/redpanda/config.rpm.txt"
+rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"
 rp_conf_loc_rpm: "/etc/yum.repos.d/redpanda-redpanda.repo"
-rp_key_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
-rp_config_url_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/config.deb.txt"
+rp_key_deb: "{{ redpanda_base_url }}/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
 rp_conf_loc_deb: "/etc/apt/sources.list.d/redpanda.list"
 rp_key_path_deb: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg"
+rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
 rpm_prerequisite_packages:
   - curl
   - yum-utils
@@ -43,3 +43,6 @@ debian_prerequisite_packages:
   - apt-transport-https
   - ca-certificates
   - gnupg
+  - iotop
+  - mdadm
+  - xfsprogs

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -28,8 +28,10 @@ cloud_storage_enable_remote_write: "true"
 cloud_storage_enable_remote_read: "true"
 rp_key_rpm: "https://dl.redpanda.com/public/redpanda/gpg.988A7B0A4918BC85.key"
 rp_config_url_rpm: "https://dl.redpanda.com/public/redpanda/config.rpm.txt"
+rp_conf_loc_rpm: "/etc/yum.repos.d/redpanda-redpanda.repo"
 rp_key_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
 rp_config_url_deb: "https://dl.redpanda.com/sMIXnoa7DK12JW4A/redpanda/config.deb.txt"
+rp_conf_loc_deb: "/etc/apt/sources.list.d/redpanda.list"
 rpm_prerequisite_packages:
   - curl
   - yum-utils

--- a/roles/redpanda_broker/tasks/data-dir-perms.yml
+++ b/roles/redpanda_broker/tasks/data-dir-perms.yml
@@ -1,0 +1,8 @@
+- name: Set data dir permissions
+  ansible.builtin.file:
+    dest: "{{ redpanda_base_dir }}"
+    src: "{{ repdanda_mount_dir }}"
+    state: link
+    owner: root
+    group: root
+    mode: "0775"

--- a/roles/redpanda_broker/tasks/install-node-deps.yml
+++ b/roles/redpanda_broker/tasks/install-node-deps.yml
@@ -35,14 +35,16 @@
     force_apt_get: true
   when: ansible_os_family == 'Debian'
 
-- name: Node dependencies - install base deps - debian
-  tags:
-    - node_deps
-  ansible.builtin.apt:
-    name:
-      - iotop
-      - mdadm
-      - xfsprogs
+- name: Install Debian prerequisites
+  package:
+    name: "{{ debian_prerequisite_packages }}"
     state: present
-    update_cache: true
+    update_cache: yes
   when: ansible_os_family == 'Debian'
+
+- name: Install RPM packages
+  package:
+    name: "{{ rpm_prerequisite_packages }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'RedHat'

--- a/roles/redpanda_broker/tasks/install-redpanda.yml
+++ b/roles/redpanda_broker/tasks/install-redpanda.yml
@@ -1,9 +1,25 @@
 ---
-- name: Download GPG key (Debian)
-  get_url:
+- name: Download GPG key
+  uri:
     url: "{{ rp_key_deb }}"
-    dest: /etc/apt/trusted.gpg.d/redpanda-redpanda-archive-keyring.gpg
-  become: true
+    return_content: yes
+    dest: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.asc"
+  when: ansible_os_family == 'Debian'
+
+- name:  Add Redpanda repository
+  apt_repository:
+    filename: "redpanda-redpanda"
+    mode: 0644
+    repo:  "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.asc] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Add Redpanda repository (source)
+  apt_repository:
+    filename: "redpanda-redpanda-src"
+    mode: 0644
+    repo: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.asc] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+    update_cache: yes
   when: ansible_os_family == 'Debian'
 
 - name: Install Debian prerequisites
@@ -31,10 +47,14 @@
   set_fact:
     conf_url: "{{ rp_config_url_deb if ansible_os_family == 'Debian' else rp_config_url_rpm }}"
 
+- name: Set conf location based on OS family
+  set_fact:
+    conf_dest: "{{ rp_conf_loc_deb if ansible_os_family == 'Debian' else rp_conf_loc_rpm }}"
+
 - name: Fetch Redpanda configuration
   uri:
-    url: "{{ conf_url }}?distro={{ ansible_distribution }}&codename={{ ansible_distribution_release }}&version={{ ansible_distribution_version }}&arch={{ ansible_architecture }}"
-    dest: /etc/yum.repos.d/redpanda-redpanda.repo
+    url: "{{ (conf_url ~ '?distro=' ~ ansible_distribution ~ '&codename=' ~ ansible_distribution_release ~ '&version=' ~ ansible_distribution_version ~ '&arch=' ~ ansible_architecture) | replace(' ', '%20') | lower }}"
+    dest: "{{ conf_dest }}"
     return_content: yes
     follow_redirects: all
     force: yes

--- a/roles/redpanda_broker/tasks/install-redpanda.yml
+++ b/roles/redpanda_broker/tasks/install-redpanda.yml
@@ -2,78 +2,88 @@
 - name: Download and import Redpanda GPG Key
   shell: |
     curl -1sLf "{{ rp_key_deb }}" | gpg --dearmor > {{ rp_key_path_deb }}
+  when: ansible_os_family == 'Debian'
 
-- name:  Add Redpanda repository
+- name:  Add Redpanda DEB repository
   apt_repository:
     filename: "redpanda-redpanda"
     mode: 0644
-    repo:  "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+    repo:  "{{ rp_repo_signing_deb }}"
     update_cache: yes
   when: ansible_os_family == 'Debian'
 
-- name: Add Redpanda repository (source)
+- name: Add Redpanda DEB repository (source)
   apt_repository:
     filename: "redpanda-redpanda-src"
     mode: 0644
-    repo: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+    repo: "{{ rp_repo_signing_src_deb }}"
     update_cache: yes
   when: ansible_os_family == 'Debian'
 
-- name: Install Debian prerequisites
-  package:
-    name: "{{ debian_prerequisite_packages }}"
-    state: present
-    update_cache: yes
-  when: ansible_os_family == 'Debian'
 
-- name: Install GPG key (RedHat)
+- name: Add redpanda-redpanda RPM repository
+  ansible.builtin.yum_repository:
+    name: 'redpanda-redpanda'
+    description: 'redpanda-redpanda'
+    baseurl: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch"
+    gpgkey: "{{ rp_key_rpm }}"
+    repo_gpgcheck: yes
+    gpgcheck: yes
+    enabled: yes
+    sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
+    sslverify: yes
+    metadata_expire: 300
+    skip_if_unavailable: yes
+  when: ansible_os_family == 'RedHat'
+
+- name: Add redpanda-redpanda-noarch RPM repository
+  ansible.builtin.yum_repository:
+    name: 'redpanda-redpanda-noarch'
+    description: 'redpanda-redpanda-noarch'
+    baseurl: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch"
+    gpgkey: "{{ rp_key_rpm }}"
+    repo_gpgcheck: yes
+    gpgcheck: yes
+    enabled: yes
+    sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
+    sslverify: yes
+    metadata_expire: 300
+    skip_if_unavailable: yes
+  when: ansible_os_family == 'RedHat'
+
+- name: Add redpanda-redpanda-source RPM repository
+  ansible.builtin.yum_repository:
+    name: 'redpanda-redpanda-source'
+    description: 'redpanda-redpanda-source'
+    baseurl: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch"
+    gpgkey: "{{ rp_key_rpm }}"
+    repo_gpgcheck: yes
+    gpgcheck: yes
+    enabled: yes
+    sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
+    sslverify: yes
+    metadata_expire: 300
+    skip_if_unavailable: yes
+  when: ansible_os_family == 'RedHat'
+
+- name: Install GPG key (RPM)
   ansible.builtin.rpm_key:
     state: present
     key: "{{ rp_key_rpm }}"
   when: ansible_os_family == 'RedHat'
 
-- name: Install prerequisite packages
-  package:
-    name: "{{ rpm_prerequisite_packages }}"
-    state: present
-    update_cache: yes
-  when: ansible_os_family == 'RedHat'
-
-
-- name: Set fact based on OS family
+- name: Set fact for package name
   set_fact:
-    conf_url: "{{ rp_config_url_deb if ansible_os_family == 'Debian' else rp_config_url_rpm }}"
-
-- name: Set conf location based on OS family
-  set_fact:
-    conf_dest: "{{ rp_conf_loc_deb if ansible_os_family == 'Debian' else rp_conf_loc_rpm }}"
-
-- name: Fetch Redpanda configuration
-  uri:
-    url: "{{ (conf_url ~ '?distro=' ~ ansible_distribution ~ '&codename=' ~ ansible_distribution_release ~ '&version=' ~ ansible_distribution_version ~ '&arch=' ~ ansible_architecture) | replace(' ', '%20') | lower }}"
-    dest: "{{ conf_dest }}"
-    return_content: yes
-    follow_redirects: all
-    force: yes
-  register: redpanda_config_result
+    redpanda_package_name: "redpanda{{ '' if redpanda_version=='latest' else ('=' if ansible_os_family == 'Debian' else '-') + redpanda_version }}"
 
 - name: Install redpanda from repository
   ansible.builtin.package:
     name:
-      - redpanda{{ '' if redpanda_version=='latest' else '=' + redpanda_version }}
+      - "{{ redpanda_package_name }}"
     state: "{{ redpanda_install_status }}"
     update_cache: true
   register: package_result
-  when: ansible_os_family == 'Debian'
 
-- name: Install redpanda from repository
-  ansible.builtin.package:
-    name:
-      - redpanda{{ '' if redpanda_version=='latest' else '-' + redpanda_version }}
-    state: "{{ redpanda_install_status }}"
-    update_cache: true
-  register: package_result
-  when: ansible_os_family == 'RedHat'
 
 - name: Set data dir file perms
   ansible.builtin.file:

--- a/roles/redpanda_broker/tasks/install-redpanda.yml
+++ b/roles/redpanda_broker/tasks/install-redpanda.yml
@@ -1,17 +1,47 @@
 ---
-- name: Download the Redpanda repo script
-  ansible.builtin.get_url:
-    url: "{{ redpanda_repo_script }}"
-    dest: "/tmp/redpanda_repo_script.sh"
-    mode: '0755'
+- name: Download GPG key (Debian)
+  get_url:
+    url: "{{ rp_key_deb }}"
+    dest: /etc/apt/trusted.gpg.d/redpanda-redpanda-archive-keyring.gpg
+  become: true
+  when: ansible_os_family == 'Debian'
 
-- name: Execute the Redpanda repo script
-  ansible.builtin.command:
-    cmd: sudo -E /tmp/redpanda_repo_script.sh
-  changed_when: false
+- name: Install Debian prerequisites
+  package:
+    name: "{{ debian_prerequisite_packages }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Install GPG key (RedHat)
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ rp_key_rpm }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: Install prerequisite packages
+  package:
+    name: "{{ rpm_prerequisite_packages }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'RedHat'
+
+
+- name: Set fact based on OS family
+  set_fact:
+    conf_url: "{{ rp_config_url_deb if ansible_os_family == 'Debian' else rp_config_url_rpm }}"
+
+- name: Fetch Redpanda configuration
+  uri:
+    url: "{{ conf_url }}?distro={{ ansible_distribution }}&codename={{ ansible_distribution_release }}&version={{ ansible_distribution_version }}&arch={{ ansible_architecture }}"
+    dest: /etc/yum.repos.d/redpanda-redpanda.repo
+    return_content: yes
+    follow_redirects: all
+    force: yes
+  register: redpanda_config_result
 
 - name: Install redpanda from repository
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name:
       - redpanda{{ '' if redpanda_version=='latest' else '=' + redpanda_version }}
     state: "{{ redpanda_install_status }}"
@@ -20,7 +50,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install redpanda from repository
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name:
       - redpanda{{ '' if redpanda_version=='latest' else '-' + redpanda_version }}
     state: "{{ redpanda_install_status }}"

--- a/roles/redpanda_broker/tasks/install-redpanda.yml
+++ b/roles/redpanda_broker/tasks/install-redpanda.yml
@@ -1,16 +1,13 @@
 ---
-- name: Download GPG key
-  uri:
-    url: "{{ rp_key_deb }}"
-    return_content: yes
-    dest: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.asc"
-  when: ansible_os_family == 'Debian'
+- name: Download and import Redpanda GPG Key
+  shell: |
+    curl -1sLf "{{ rp_key_deb }}" | gpg --dearmor > {{ rp_key_path_deb }}
 
 - name:  Add Redpanda repository
   apt_repository:
     filename: "redpanda-redpanda"
     mode: 0644
-    repo:  "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.asc] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+    repo:  "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
     update_cache: yes
   when: ansible_os_family == 'Debian'
 
@@ -18,7 +15,7 @@
   apt_repository:
     filename: "redpanda-redpanda-src"
     mode: 0644
-    repo: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.asc] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+    repo: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] https://dl.redpanda.com/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
     update_cache: yes
   when: ansible_os_family == 'Debian'
 

--- a/roles/redpanda_broker/tasks/main.yml
+++ b/roles/redpanda_broker/tasks/main.yml
@@ -36,6 +36,12 @@
   when:
     - handle_cert_install | default(false) | bool
 
+# sets permissions on the data directory -- separate from creating for increased flexibility
+- name: Set data dir perms
+  ansible.builtin.include_tasks: data-dir-perms.yml
+  when:
+    - data_dir_perms | default(true) | bool
+
 - name: Install Redpanda
   ansible.builtin.include_tasks: install-redpanda.yml
 

--- a/roles/redpanda_broker/tasks/prepare-data-dir.yml
+++ b/roles/redpanda_broker/tasks/prepare-data-dir.yml
@@ -65,19 +65,8 @@
 
 - name: Prep Data Dir - Create data path
   ansible.builtin.file:
-    path: /mnt/vectorized/redpanda
+    path: "{{ repdanda_mount_dir }}"
     state: directory
-    owner: root
-    group: root
-    mode: "0775"
-  tags:
-    - prep_data_dir
-
-- name: Prep Data Dir - Set permissions
-  ansible.builtin.file:
-    dest: /var/lib/redpanda
-    src: /mnt/vectorized/redpanda
-    state: link
     owner: root
     group: root
     mode: "0775"

--- a/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -22,7 +22,7 @@
 #
 - name: Generate configurations
   ansible.builtin.set_fact:
-    configuration: "{{ configuration | combine(lookup('template', custom_config_template.template) | from_json, recursive=True) }}"
+    configuration: "{{ configuration | combine(lookup('template', custom_config_template.template), recursive=True) }}"
   loop: "{{ custom_config_templates }}"
   loop_control:
     loop_var: custom_config_template

--- a/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -22,7 +22,7 @@
 #
 - name: Generate configurations
   ansible.builtin.set_fact:
-    configuration: "{{ configuration | combine(lookup('template', custom_config_template.template) | from_yaml, recursive=True) }}"
+    configuration: "{{ configuration | combine(lookup('template', custom_config_template.template) | from_json, recursive=True) }}"
   loop: "{{ custom_config_templates }}"
   loop_control:
     loop_var: custom_config_template

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -1,55 +1,78 @@
-cluster:
-  rpc_server_tcp_recv_buf: 65536
-  enable_rack_awareness: {{ true if rack is defined and rack != -1 else false }}
-node:
-  organization: "{{ redpanda_organization }}"
-  cluster_id: "{{ redpanda_cluster_id }}"
-  redpanda:
-    empty_seed_starts_cluster: false
-    advertised_kafka_api:
-    - address: {{ hostvars[inventory_hostname].advertised_ip }}
-      port: {{ redpanda_kafka_port }}
-    advertised_rpc_api:
-      address: {{ hostvars[inventory_hostname].private_ip }}
-      port: {{ redpanda_rpc_port }}
-    data_directory: "{{ redpanda_data_directory }}"
-    rpc_server:
-      address: {{ hostvars[inventory_hostname].private_ip }}
-      port: {{ redpanda_rpc_port }}
-    kafka_api:
-    - address: {{ hostvars[inventory_hostname].private_ip }}
-      port: {{ redpanda_kafka_port }}
-    admin:
-    - address: {{ hostvars[inventory_hostname].private_ip }}
-      port: {{ redpanda_admin_api_port }}
-    seed_servers:
-{% for host in groups["redpanda"] %}
-      - host:
-          address: {{ hostvars[host]['private_ip'] }}
-          port: {{ redpanda_rpc_port }}
-{% endfor %}
-{% if rack is defined %}
-    rack: "{{ rack | default('null') }}"
-{% endif %}
-  rpk:
-    kafka_api:
-      brokers:
-{% for host in groups["redpanda"] %}
-      - {{ hostvars[host]['private_ip'] }}:{{ redpanda_kafka_port }}
-{% endfor %}
-    admin_api:
-      addresses:
-{% for host in groups["redpanda"] %}
-      - {{ hostvars[host]['private_ip'] }}:{{ redpanda_admin_api_port }}
-{% endfor %}
-    tune_network: true
-    tune_disk_scheduler: true
-    tune_disk_nomerges: true
-    tune_disk_write_cache: true
-    tune_disk_irq: true
-    tune_cpu: true
-    tune_aio_events: true
-    tune_clocksource: true
-    tune_swappiness: true
-    tune_ballast_file: true
-  pandaproxy: {}
+{
+  "cluster": {
+    "rpc_server_tcp_recv_buf": 65536,
+    "enable_rack_awareness": "{{ true if rack is defined and rack != -1 else false }}"
+  },
+  "node": {
+    "organization": "{{ redpanda_organization }}",
+    "cluster_id": "{{ redpanda_cluster_id }}",
+    "redpanda": {
+      "empty_seed_starts_cluster": false,
+      "advertised_kafka_api": [
+        {
+          "address": "{{ hostvars[inventory_hostname].advertised_ip }}",
+          "port": "{{ redpanda_kafka_port }}"
+        }
+      ],
+      "advertised_rpc_api": {
+        "address": "{{ hostvars[inventory_hostname].private_ip }}",
+        "port": "{{ redpanda_rpc_port }}"
+      },
+      "data_directory": "{{ redpanda_data_directory }}",
+      "rpc_server": {
+        "address": "{{ hostvars[inventory_hostname].private_ip }}",
+        "port": "{{ redpanda_rpc_port }}"
+      },
+      "kafka_api": [
+        {
+          "address": "{{ hostvars[inventory_hostname].private_ip }}",
+          "port": "{{ redpanda_kafka_port }}"
+        }
+      ],
+      "admin": [
+        {
+          "address": "{{ hostvars[inventory_hostname].private_ip }}",
+          "port": "{{ redpanda_admin_api_port }}"
+        }
+      ],
+      "seed_servers": [
+        "{% for host in groups['redpanda'] %}",
+        {
+          "host": {
+            "address": "{{ hostvars[host]['private_ip'] }}",
+            "port": "{{ redpanda_rpc_port }}"
+          }
+        },
+        "{% endfor %}"
+      ],
+      "rack": "{% if rack is defined %}{{ rack | default('null') }}{% endif %}"
+    },
+    "rpk": {
+      "kafka_api": {
+        "brokers": [
+          "{% for host in groups['redpanda'] %}",
+          "{{ hostvars[host]['private_ip'] }}:{{ redpanda_kafka_port }}",
+          "{% endfor %}"
+        ]
+      },
+      "admin_api": {
+        "addresses": [
+          "{% for host in groups['redpanda'] %}",
+          "{{ hostvars[host]['private_ip'] }}:{{ redpanda_admin_api_port }}",
+          "{% endfor %}"
+        ]
+      },
+      "tune_network": true,
+      "tune_disk_scheduler": true,
+      "tune_disk_nomerges": true,
+      "tune_disk_write_cache": true,
+      "tune_disk_irq": true,
+      "tune_cpu": true,
+      "tune_aio_events": true,
+      "tune_clocksource": true,
+      "tune_swappiness": true,
+      "tune_ballast_file": true
+    },
+    "pandaproxy": {}
+  }
+}

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -36,30 +36,30 @@
         }
       ],
       "seed_servers": [
-        "{% for host in groups['redpanda'] %}",
+        {% for host in groups['redpanda'] %}
         {
           "host": {
             "address": "{{ hostvars[host]['private_ip'] }}",
             "port": "{{ redpanda_rpc_port }}"
           }
-        },
-        "{% endfor %}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
       ],
       "rack": "{% if rack is defined %}{{ rack | default('null') }}{% endif %}"
     },
     "rpk": {
       "kafka_api": {
         "brokers": [
-          "{% for host in groups['redpanda'] %}",
-          "{{ hostvars[host]['private_ip'] }}:{{ redpanda_kafka_port }}",
-          "{% endfor %}"
+        {% for host in groups['redpanda'] %}
+        "{{ hostvars[host]['private_ip'] }}:{{ redpanda_kafka_port }}"{% if not loop.last %},{% endif %}
+        {% endfor %}
         ]
       },
       "admin_api": {
         "addresses": [
-          "{% for host in groups['redpanda'] %}",
-          "{{ hostvars[host]['private_ip'] }}:{{ redpanda_admin_api_port }}",
-          "{% endfor %}"
+          {% for host in groups['redpanda'] %}
+          "{{ hostvars[host]['private_ip'] }}:{{ redpanda_admin_api_port }}"{% if not loop.last %},{% endif %}
+          {% endfor %}
         ]
       },
       "tune_network": true,

--- a/roles/redpanda_broker/templates/configs/tiered_storage.j2
+++ b/roles/redpanda_broker/templates/configs/tiered_storage.j2
@@ -1,8 +1,10 @@
-cluster:
-  cloud_storage_bucket: {{ tiered_storage_bucket_name if tiered_storage_bucket_name is defined }}
-  cloud_storage_enable_remote_read: {{ cloud_storage_enable_remote_read }}
-  cloud_storage_enable_remote_write: {{ cloud_storage_enable_remote_write }}
-  cloud_storage_region: {{ cloud_storage_region if cloud_storage_region is defined }}
-  cloud_storage_credentials_source: {{ cloud_storage_credentials_source }}
-  # cloud_storage_enabled must be after other cloud_storage parameters
-  cloud_storage_enabled: {{ true if tiered_storage_bucket_name is defined and tiered_storage_bucket_name|d('')|length > 0 else false }}
+{
+"cluster": {
+"cloud_storage_bucket": "{{ tiered_storage_bucket_name if tiered_storage_bucket_name is defined }}",
+"cloud_storage_enable_remote_read": "{{ cloud_storage_enable_remote_read }}",
+"cloud_storage_enable_remote_write": "{{ cloud_storage_enable_remote_write }}",
+"cloud_storage_region": "{{ cloud_storage_region if cloud_storage_region is defined }}",
+"cloud_storage_credentials_source": "{{ cloud_storage_credentials_source }}",
+"cloud_storage_enabled": "{{ true if tiered_storage_bucket_name is defined and tiered_storage_bucket_name|d('')|length > 0 else false }}"
+}
+}

--- a/roles/redpanda_broker/templates/configs/tls.j2
+++ b/roles/redpanda_broker/templates/configs/tls.j2
@@ -1,27 +1,39 @@
-node:
-  redpanda:
-    admin_api_tls:
-      enabled: true
-      require_client_auth: false
-      key_file: "{{ redpanda_key_file }}"
-      cert_file: "{{ redpanda_cert_file }}"
-      truststore_file: "{{ redpanda_truststore_file }}"
-    kafka_api_tls:
-      enabled: true
-      require_client_auth: false
-      key_file: "{{ redpanda_key_file }}"
-      cert_file: "{{ redpanda_cert_file }}"
-      truststore_file: "{{ redpanda_truststore_file }}"
-    rpc_server_tls:
-      enabled: true
-      require_client_auth: false
-      key_file: "{{ redpanda_key_file }}"
-      cert_file: "{{ redpanda_cert_file }}"
-      truststore_file: "{{ redpanda_truststore_file }}"
-  rpk:
-    admin_api:
-      tls:
-        truststore_file: "{{ redpanda_truststore_file }}"
-    kafka_api:
-      tls:
-        truststore_file: "{{ redpanda_truststore_file }}"
+{
+  "node": {
+    "redpanda": {
+      "admin_api_tls": {
+        "enabled": true,
+        "require_client_auth": false,
+        "key_file": "{{ redpanda_key_file }}",
+        "cert_file": "{{ redpanda_cert_file }}",
+        "truststore_file": "{{ redpanda_truststore_file }}"
+      },
+      "kafka_api_tls": {
+        "enabled": true,
+        "require_client_auth": false,
+        "key_file": "{{ redpanda_key_file }}",
+        "cert_file": "{{ redpanda_cert_file }}",
+        "truststore_file": "{{ redpanda_truststore_file }}"
+      },
+      "rpc_server_tls": {
+        "enabled": true,
+        "require_client_auth": false,
+        "key_file": "{{ redpanda_key_file }}",
+        "cert_file": "{{ redpanda_cert_file }}",
+        "truststore_file": "{{ redpanda_truststore_file }}"
+      }
+    },
+    "rpk": {
+      "admin_api": {
+        "tls": {
+          "truststore_file": "{{ redpanda_truststore_file }}"
+        }
+      },
+      "kafka_api": {
+        "tls": {
+          "truststore_file": "{{ redpanda_truststore_file }}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
  This PR makes the necessary changes to remove the install script from the repo in support of the air gap project while replacing ever more static strings with variables users can set to improve their ability to control the install process. In addition I've swapped us from YAML to JSON for the templates so that we're better able to modularly include/exclude elements without running into mapping issues.
  
  - Bash Install Script Removal for RPM/DEB (Ansible changes)
    - [x] Eliminate bash install script for deb
    - [x] Eliminate bash install script for rpm
    - [x] Ensure there is a var to pass in the location of the install files as either a path or a hyperlink
    - [x] Split permissions for data directory from creation of data directory
    - [x] Switch templates from YAML to JSON for ease of future modification