### PR TITLE
Add retry to issue certs

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.1
+version: 0.4.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/demo_certs/tasks/issue-certs.yml
+++ b/roles/demo_certs/tasks/issue-certs.yml
@@ -66,3 +66,7 @@
         -batch
     creates: tls/certs/{{ansible_hostname}}/node.crt
   delegate_to: 127.0.0.1
+  register: result_issue_certs
+  until: result_issue_certs.rc == 0
+  retries: 3
+  delay: 5


### PR DESCRIPTION
This task often fails due to a race condition with "Unable to rename /workdir/ansible/tls/ca/serial.txt.new to /workdir/ansible/tls/ca/serial.txt". While we could fix this task by setting serial to 1, this would render the playbook unusable as the number of brokers increases. Also, it usually doesn't hit the race condition. As an alternative solution to a really annoying but ultimately harmless bug I've added a retry with a small delay for errors.