### PR TITLE
fixes the lack of an unstable version for console

### DIFF
--- a/roles/redpanda_broker/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-deb-repository.yml
@@ -1,10 +1,10 @@
 ---
 - name: Set Redpanda GPG Key and Repository details
   set_fact:
-    rp_key_deb_actual: "{{ is_using_unstable | bool | ternary(rp_key_deb_unstable, rp_key_deb) }}"
-    rp_key_path_deb_actual: "{{ is_using_unstable | bool | ternary(rp_key_path_deb_unstable, rp_key_path_deb) }}"
-    rp_repo_signing_deb_actual: "{{ is_using_unstable | bool | ternary(rp_repo_signing_deb_unstable, rp_repo_signing_deb) }}"
-    rp_repo_signing_src_deb_actual: "{{ is_using_unstable | bool | ternary(rp_repo_signing_src_deb_unstable, rp_repo_signing_src_deb) }}"
+    rp_key_deb_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_key_deb_unstable, rp_key_deb) }}"
+    rp_key_path_deb_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_key_path_deb_unstable, rp_key_path_deb) }}"
+    rp_repo_signing_deb_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_repo_signing_deb_unstable, rp_repo_signing_deb) }}"
+    rp_repo_signing_src_deb_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_repo_signing_src_deb_unstable, rp_repo_signing_src_deb) }}"
 
 - name: Download and import Redpanda GPG Key with proxy
   become: true

--- a/roles/redpanda_broker/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-rpm-repository.yml
@@ -1,11 +1,11 @@
 ---
 - name: Set Redpanda RPM and GPG Key details
   set_fact:
-    rp_key_rpm_actual: "{{ is_using_unstable | bool | ternary(rp_key_rpm_unstable, rp_key_rpm) }}"
-    rp_standard_rpm_actual: "{{ is_using_unstable | bool | ternary(rp_standard_rpm_unstable, rp_standard_rpm) }}"
-    rp_noarch_rpm_actual: "{{ is_using_unstable | bool | ternary(rp_noarch_rpm_unstable, rp_noarch_rpm) }}"
-    rp_source_rpm_actual: "{{ is_using_unstable | bool | ternary(rp_source_rpm_unstable, rp_source_rpm) }}"
-    repo_name_prefix: "{{ is_using_unstable | bool | ternary('redpanda-redpanda-unstable', 'redpanda-redpanda') }}"
+    rp_key_rpm_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_key_rpm_unstable, rp_key_rpm) }}"
+    rp_standard_rpm_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_standard_rpm_unstable, rp_standard_rpm) }}"
+    rp_noarch_rpm_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_noarch_rpm_unstable, rp_noarch_rpm) }}"
+    rp_source_rpm_actual: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary(rp_source_rpm_unstable, rp_source_rpm) }}"
+    repo_name_prefix: "{{ (is_using_unstable | bool | default(false) and not (install_console | bool | default(false))) | ternary('redpanda-redpanda-unstable', 'redpanda-redpanda') }}"
 
 - name: Add redpanda-redpanda RPM repository
   ansible.builtin.yum_repository:


### PR DESCRIPTION
When install_console is true we default to standard rather than unstable as no unstable version is published to our apt/dnf repositories. 