### PR TITLE
Broker: enable schema registry 

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.11
+version: 0.4.12
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -7,6 +7,7 @@ redpanda_mode: production
 redpanda_admin_api_port: 9644
 redpanda_kafka_port: 9092
 redpanda_rpc_port: 33145
+redpanda_schema_registry_port: 8081
 
 redpanda_use_staging_repo: false
 redpanda_base_url: "https://dl.redpanda.com"

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -74,6 +74,14 @@
       "tune_ballast_file": true
     },
     "pandaproxy": {},
-    "schema_registry": {}
+    "schema_registry": {
+        "schema_registry_api": [
+        {
+          "address": "0.0.0.0",
+          "port": "{{ redpanda_schema_registry_port }}"
+        }
+      ],
+      "schema_registry_replication_factor": {{schema_registry_replication_factor | default(1)}}
+    }
   }
 }

--- a/roles/redpanda_broker/templates/configs/tls.j2
+++ b/roles/redpanda_broker/templates/configs/tls.j2
@@ -34,6 +34,17 @@
           "truststore_file": "{{ redpanda_truststore_file }}"
         }
       }
+    },
+    "schema_registry":{
+      "schema_registry_api_tls": [
+        {
+          "enabled": true,
+          "require_client_auth": false,
+          "key_file": "{{ redpanda_key_file }}",
+          "cert_file": "{{ redpanda_cert_file }}",
+          "truststore_file": "{{ redpanda_truststore_file }}"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR introduces the schema registry configuration for the redpanda.yaml and enables schema registry on start. It supports TLS configurations too.
