### PR TITLE
Changes for GCP Proxy

### DIFF
--- a/roles/redpanda_broker/tasks/install-rp-deb.yml
+++ b/roles/redpanda_broker/tasks/install-rp-deb.yml
@@ -1,21 +1,8 @@
 ---
-- name: Check if VM is in GCP
-  uri:
-    url: "http://metadata.google.internal/computeMetadata/v1/instance/id"
-    headers:
-      Metadata-Flavor: "Google"
-    method: GET
-    timeout: 10
-    validate_certs: no
-    status_code: 200
-    return_content: no
-  register: gcp_metadata
-  ignore_errors: yes
-
-- name: Set fact if in GCP
+- name: Set custom fact based on ansible_system_vendor
   set_fact:
     using_gcp: true
-  when: gcp_metadata.status == 200
+  when: ansible_system_vendor == 'Google'
 
 - name: Set fact for package name
   set_fact:

--- a/roles/redpanda_broker/tasks/install-rp-deb.yml
+++ b/roles/redpanda_broker/tasks/install-rp-deb.yml
@@ -1,9 +1,27 @@
 ---
+- name: Check if VM is in GCP
+  uri:
+    url: "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    headers:
+      Metadata-Flavor: "Google"
+    method: GET
+    timeout: 10
+    validate_certs: no
+    status_code: 200
+    return_content: no
+  register: gcp_metadata
+  ignore_errors: yes
+
+- name: Set fact if in GCP
+  set_fact:
+    using_gcp: true
+  when: gcp_metadata.status == 200
+
 - name: Set fact for package name
   set_fact:
     redpanda_package_name: "redpanda{{ '' if redpanda_version=='latest' else ('=' if ansible_os_family == 'Debian' else '-') + redpanda_version }}"
 
-- name: Install redpanda from repository
+- name: Install redpanda from repository (Proxy)
   ansible.builtin.package:
     name:
       - "{{ redpanda_package_name }}"
@@ -12,15 +30,28 @@
   environment:
     https_proxy: "{{ https_proxy_value | default('') }}"
     http_proxy: "{{ https_proxy_value | default('') }}"
-  when: https_proxy_value is defined and https_proxy_value | length > 0
+  when:
+    - https_proxy_value is defined
+    - https_proxy_value | length > 0
+    - (using_gcp | default(false)) is false
 
-- name: Install redpanda from repository
+- name: Install redpanda from repository (Standard)
   ansible.builtin.package:
     name:
       - "{{ redpanda_package_name }}"
     state: "{{ redpanda_install_status }}"
     update_cache: true
-  when: https_proxy_value is not defined or https_proxy_value | length == 0
+  when: https_proxy_value is not defined and (using_gcp | default(false)) is false
+
+- name: Install redpanda from repository (GCP)
+  ansible.builtin.package:
+    name:
+      - "{{ redpanda_package_name }}"
+    state: "{{ redpanda_install_status }}"
+    update_cache: true
+    allow_unauthenticated: yes
+  when: (using_gcp | default(false)) is not false
+
 
 - name: Set data dir file perms
   ansible.builtin.file:

--- a/roles/system_setup/tasks/install-node-deps-deb.yml
+++ b/roles/system_setup/tasks/install-node-deps-deb.yml
@@ -1,4 +1,22 @@
 ---
+- name: Check if VM is in GCP
+  uri:
+    url: "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    headers:
+      Metadata-Flavor: "Google"
+    method: GET
+    timeout: 10
+    validate_certs: no
+    status_code: 200
+    return_content: no
+  register: gcp_metadata
+  ignore_errors: yes
+
+- name: Set fact if in GCP
+  set_fact:
+    using_gcp: true
+  when: gcp_metadata.status == 200
+
 - name: Node dependencies - Set APT proxy
   template:
     src: apt_proxy.j2
@@ -8,6 +26,7 @@
   when:
     - https_proxy_value is defined and https_proxy_value | length > 0
     - (create_pkg_mgr_proxy | default(false)) is true
+    - (using_gcp | default(false)) is false
 
 - name: Node dependencies - update packages - debian
   tags:

--- a/roles/system_setup/tasks/install-node-deps-deb.yml
+++ b/roles/system_setup/tasks/install-node-deps-deb.yml
@@ -1,21 +1,8 @@
 ---
-- name: Check if VM is in GCP
-  uri:
-    url: "http://metadata.google.internal/computeMetadata/v1/instance/id"
-    headers:
-      Metadata-Flavor: "Google"
-    method: GET
-    timeout: 10
-    validate_certs: no
-    status_code: 200
-    return_content: no
-  register: gcp_metadata
-  ignore_errors: yes
-
-- name: Set fact if in GCP
+- name: Set custom fact based on ansible_system_vendor
   set_fact:
     using_gcp: true
-  when: gcp_metadata.status == 200
+  when: ansible_system_vendor == 'Google'
 
 - name: Node dependencies - Set APT proxy
   template:

--- a/roles/system_setup/tasks/install-node-deps-rpm.yml
+++ b/roles/system_setup/tasks/install-node-deps-rpm.yml
@@ -1,4 +1,22 @@
 ---
+- name: Check if VM is in GCP
+  uri:
+    url: "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    headers:
+      Metadata-Flavor: "Google"
+    method: GET
+    timeout: 10
+    validate_certs: no
+    status_code: 200
+    return_content: no
+  register: gcp_metadata
+  ignore_errors: yes
+
+- name: Set fact if in GCP
+  set_fact:
+    using_gcp: true
+  when: gcp_metadata.status == 200
+
 - name: Node dependencies - Set DNF proxy
   template:
     src: dnf_proxy.j2
@@ -8,6 +26,7 @@
   when:
     - rpm_proxy is defined and rpm_proxy | length > 0
     - (create_pkg_mgr_proxy | default(false)) is true
+    - (using_gcp | default(false)) is false
 
 - name: Node dependencies - RPM setup
   tags:

--- a/roles/system_setup/tasks/install-node-deps-rpm.yml
+++ b/roles/system_setup/tasks/install-node-deps-rpm.yml
@@ -1,21 +1,8 @@
 ---
-- name: Check if VM is in GCP
-  uri:
-    url: "http://metadata.google.internal/computeMetadata/v1/instance/id"
-    headers:
-      Metadata-Flavor: "Google"
-    method: GET
-    timeout: 10
-    validate_certs: no
-    status_code: 200
-    return_content: no
-  register: gcp_metadata
-  ignore_errors: yes
-
-- name: Set fact if in GCP
+- name: Set custom fact based on ansible_system_vendor
   set_fact:
     using_gcp: true
-  when: gcp_metadata.status == 200
+  when: ansible_system_vendor == 'Google'
 
 - name: Node dependencies - Set DNF proxy
   template:


### PR DESCRIPTION
Basically, google has some internal access points for various public registries that are messed up by using apt/dnf proxying. I've added some workarounds to eliminate the issue. There's no reason to override Google's functionality since it's strictly superior to using Squid.