### PR TITLE
Add GCP Storage API to enable tiered storage

### DIFF
--- a/roles/redpanda_broker/templates/configs/tiered_storage.j2
+++ b/roles/redpanda_broker/templates/configs/tiered_storage.j2
@@ -5,6 +5,8 @@
 "cloud_storage_enable_remote_write": "{{ cloud_storage_enable_remote_write }}",
 "cloud_storage_region": "{{ cloud_storage_region if cloud_storage_region is defined }}",
 "cloud_storage_credentials_source": "{{ cloud_storage_credentials_source }}",
-"cloud_storage_enabled": "{{ true if tiered_storage_bucket_name is defined and tiered_storage_bucket_name|d('')|length > 0 else false }}"
+"cloud_storage_enabled": "{{ true if tiered_storage_bucket_name is defined and tiered_storage_bucket_name|d('')|length > 0 else false }}"{% if cloud_storage_credentials_source == 'gcp_instance_metadata' %},
+"cloud_storage_api_endpoint": "storage.googleapis.com",
+{% endif %}
 }
 }


### PR DESCRIPTION
Had been enabling this thru the redpanda variable during testing but forgot to include it in the PR for whatever reason. 