### PR TITLE
console: add schema registry configuration

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.13
+version: 0.4.14
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/templates/console/defaults.j2
+++ b/roles/redpanda_broker/templates/console/defaults.j2
@@ -1,5 +1,26 @@
 {
   "kafka": {
+    "schemaRegistry": {
+      "enabled": true,
+      "urls": [
+        {% if enable_tls | default(false) %}
+        {% for host in advertised_ips %}
+        "https://{{ host }}:{{ redpanda_schema_registry_port }}"{% if not loop.last %},{% endif %}
+        {% endfor %}
+        {% else  %}
+        {% for host in advertised_ips %}
+        "http://{{ host }}:{{ redpanda_schema_registry_port }}"{% if not loop.last %},{% endif %}
+        {% endfor %}
+        {% endif %}
+      ]
+    },
+    "protobuf": {
+      "enabled": true,
+      "schemaRegistry": {
+        "enabled": true,
+        "refreshInterval": "5m"
+      }
+    },
     "brokers": [
       {% for host in advertised_ips %}
       "{{ host }}:{{ redpanda_kafka_port }}"{% if not loop.last %},{% endif %}


### PR DESCRIPTION
This PR adds the [Schema Registry](https://docs.redpanda.com/current/manage/console/schema-registry/) section to the redpanda-console configuration YAML. 

Now a user does not have to update the configuration to enable schema registry:

![image](https://github.com/redpanda-data/redpanda-ansible-collection/assets/59714880/de30bd7a-88c6-4f9c-93f1-07a631a3066f)

