### PR TITLE
Adds SASL/ACL management role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.15
+version: 0.4.20
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -40,6 +40,15 @@ airgap_copy_dest: "/tmp"
 
 # console
 install_console: false
+console_http_listen_port: 80
+console_https_listen_port: 443
+
+# sasl
+sasl_bootstrap_admin_user: "admin"
+sasl_bootstrap_admin_pw: "password"
+console_sasl_user: "admin"
+console_sasl_pw: "password"
+console_sasl_mechanism: "plain"
 
 # the rpms
 rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -48,7 +48,7 @@ sasl_bootstrap_admin_user: "admin"
 sasl_bootstrap_admin_pw: "password"
 console_sasl_user: "admin"
 console_sasl_pw: "password"
-console_sasl_mechanism: "plain"
+console_sasl_mechanism: "SCRAM-SHA-256"
 
 # the rpms
 rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"

--- a/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -92,6 +92,17 @@
   tags:
     rp_tuner
 
+- name: Create file with RP_BOOTSTRAP_USER for systemd
+  ansible.builtin.copy:
+    dest: "/etc/redpanda.d/superuser.conf"
+    content: "RP_BOOTSTRAP_USER={{ sasl_bootstrap_admin_user }}:{{ sasl_bootstrap_admin_pw }}\n"
+    owner: "redpanda"
+    group: "redpanda"
+    mode: "0600"
+  when:
+    - not is_initialized
+    - enable_sasl is true
+
 # ensure that systemd starts up redpanda
 - name: Start redpanda
   ansible.builtin.systemd:

--- a/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -109,6 +109,15 @@
     name: redpanda
     state: started
 
+# we don't need this file after RP has started
+- name: Delete file with RP_BOOTSTRAP_USER
+  ansible.builtin.file:
+    path: "/etc/redpanda.d/superuser.conf"
+    state: absent
+  when:
+    - is_initialized
+    - enable_sasl is true
+
 # every node must have a unique node id. we extract it for use elsewhere
 #
 - name: Establish node id

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -1,7 +1,10 @@
 {
   "cluster": {
     "rpc_server_tcp_recv_buf": 65536,
-    "enable_rack_awareness": "{{ true if rack is defined and rack != -1 else false }}"
+    "enable_rack_awareness": "{{ true if rack is defined and rack != -1 else false }}"{% if enable_sasl|default(false) %},
+    "superusers": ["admin"],
+    "enable_sasl": true
+    {% endif %}
   },
   "node": {
     "organization": "{{ redpanda_organization }}",
@@ -11,7 +14,8 @@
       "advertised_kafka_api": [
         {
           "address": "{{ hostvars[inventory_hostname].advertised_ip }}",
-          "port": "{{ redpanda_kafka_port }}"
+          "port": "{{ redpanda_kafka_port }}"{% if enable_sasl|default(false) %},
+          "authentication_method": "sasl"{% endif %}
         }
       ],
       "advertised_rpc_api": {
@@ -26,7 +30,8 @@
       "kafka_api": [
         {
           "address": "{{ hostvars[inventory_hostname].private_ip }}",
-          "port": "{{ redpanda_kafka_port }}"
+          "port": "{{ redpanda_kafka_port }}"{% if enable_sasl|default(false) %},
+          "authentication_method": "sasl"{% endif %}
         }
       ],
       "admin": [

--- a/roles/redpanda_broker/templates/console/defaults.j2
+++ b/roles/redpanda_broker/templates/console/defaults.j2
@@ -1,7 +1,7 @@
 {
   "server": {
     "listenPort": {{ console_http_listen_port }},
-    "HTTPSListenPort":{{ console_https_listen_port }}
+    "httpsListenPort":{{ console_https_listen_port }}
   },
   "kafka": {
     "schemaRegistry": {
@@ -36,7 +36,7 @@
         "enabled": true,
         "username": "{{ console_sasl_user }}",
         "password": "{{ console_sasl_pw }}",
-        "mechanism": "SCRAM-SHA-256"
+        "mechanism": "{{ console_sasl_mechanism }}"
     },{% endif %}
     "brokers": [
         {% for host in advertised_ips %}

--- a/roles/redpanda_broker/templates/console/defaults.j2
+++ b/roles/redpanda_broker/templates/console/defaults.j2
@@ -1,4 +1,8 @@
 {
+  "server": {
+    "listenPort": {{ console_http_listen_port }},
+    "HTTPSListenPort":{{ console_https_listen_port }}
+  },
   "kafka": {
     "schemaRegistry": {
       "enabled": true,
@@ -13,14 +17,13 @@
         {% endfor %}
         {% endif %}
       ]{% if enable_tls | default(false) %},
-      "tls": {
+    "tls": {
         "enabled": true,
         "caFilepath": "{{ redpanda_truststore_file }}",
         "certFilepath": "{{ redpanda_cert_file }}",
         "keyFilepath": "{{ redpanda_key_file }}",
         "insecureSkipTlsVerify": false
-      }
-      {% endif %}
+    }{% endif %}
     },
     "protobuf": {
       "enabled": true,
@@ -28,20 +31,25 @@
         "enabled": true,
         "refreshInterval": "5m"
       }
-    },
+    },{% if enable_sasl | default(false) %}
+    "sasl": {
+        "enabled": true,
+        "username": "{{ console_sasl_user }}",
+        "password": "{{ console_sasl_pw }}",
+        "mechanism": "SCRAM-SHA-256"
+    },{% endif %}
     "brokers": [
-      {% for host in advertised_ips %}
-      "{{ host }}:{{ redpanda_kafka_port }}"{% if not loop.last %},{% endif %}
-      {% endfor %}
+        {% for host in advertised_ips %}
+        "{{ host }}:{{ redpanda_kafka_port }}"{% if not loop.last %},{% endif %}
+        {% endfor %}
     ]{% if enable_tls | default(false) %},
-  "tls": {
-    "enabled": true,
-    "caFilepath": "{{ redpanda_truststore_file }}",
-    "certFilepath": "{{ redpanda_cert_file }}",
-    "keyFilepath": "{{ redpanda_key_file }}",
-    "insecureSkipTlsVerify": false
-  }
-  {% endif %}
+    "tls": {
+        "enabled": true,
+        "caFilepath": "{{ redpanda_truststore_file }}",
+        "certFilepath": "{{ redpanda_cert_file }}",
+        "keyFilepath": "{{ redpanda_key_file }}",
+        "insecureSkipTlsVerify": false
+    }{% endif %}
   },
   "redpanda": {
     "adminApi": {

--- a/roles/user_config/README.md
+++ b/roles/user_config/README.md
@@ -1,0 +1,1 @@
+## handles acl user and permission create/delete

--- a/roles/user_config/README.md
+++ b/roles/user_config/README.md
@@ -1,1 +1,40 @@
-## handles acl user and permission create/delete
+## Ansible Role: SASL Users and ACLs Manager
+This Ansible role is designed to manage Redpanda Cluster SASL users and ACLs. It provides the capability to create and delete users as well as their permissions.
+
+## Requirements
+Ansible 2.x
+
+## Security Considerations
+
+### Admin Credentials
+Ensure that the sasl_admin_username and sasl_admin_password are secure and are not hardcoded in the playbook
+
+### Password Management: 
+Ensure that passwords are managed securely. You can use a base64 encoded JSON object passed through the CLI to ensure secure password passthrough.
+
+## Role Variables
+
+| Variable                       | Description                                                                                   | Default                |
+|--------------------------------|-----------------------------------------------------------------------------------------------|------------------------|
+| `sasl_mechanism`               | The SASL mechanism to be used.                                                                | `SCRAM-SHA-256`        |
+| `acl_user_create`              | A switch to toggle between creating or deleting.                                              | `true`                 |
+| `delete_users`                 | Set this to true to enable user deletion.                                                     | `false`                |
+| `delete_permissions`           | Set this to true to enable permissions deletion.                                              | `false`                |
+| `sasl_admin_username`          | Admin username, used for authentication.                                                      | `admin`                |
+| `sasl_admin_password`          | Admin password, used for authentication.                                                      | `password`             |
+| `user_password_map_create`     | A yaml map containing the user, password, and permissions to create.                          | see defaults/main.yaml |
+| `user_password_map_delete`     | A yaml map containing the user, password, and permissions to delete.                          | see defaults/main.yaml |
+| `base64_encoded_up_map_create` | An override for user_password_map_create that enables passing in a base64 encoded JSON object | -                      | 
+| `base64_encoded_up_map_delete` | An override for user_password_map_delete that enables passing in a base64 encoded JSON object | -                      | 
+
+### Using the base64_encoded_up_map overrides
+
+To ensure there are no merge issues and to make clear the difference the role will accept as overrides for user_password_map_{create,delete}. 
+
+The intention here is to provide a CI friendly passthrough option. 
+
+For convenience, here is a one-liner to generate properly base64 encoded JSON for these variables. Note that you must have JQ installed:
+
+```shell
+jq -c . input.json | tr -d '\n' | base64
+```

--- a/roles/user_config/defaults/main.yml
+++ b/roles/user_config/defaults/main.yml
@@ -18,20 +18,26 @@ user_password_map_create:
   fizz:
     password: "buzz"
     permissions: "--operation all --topic '*' --group '*'"
+    operation: "--allow-principal"
   foo:
     password: "bar"
     permissions: "--operation all --topic '*' --group '*'"
+    operation: "--allow-principal"
   boom:
     password: "bam"
     permissions: "--operation all --topic '*' --group '*'"
+    operation: "--allow-principal"
 
 user_password_map_delete:
   fizz:
     password: "buzz"
     permissions: "--operation all --topic '*' --group '*'"
+    operation: "--allow-principal"
   foo:
     password: "bar"
     permissions: "--operation all --topic '*' --group '*'"
+    operation: "--allow-principal"
   boom:
     password: "bam"
     permissions: "--operation all --topic '*' --group '*'"
+    operation: "--allow-principal"

--- a/roles/user_config/defaults/main.yml
+++ b/roles/user_config/defaults/main.yml
@@ -1,0 +1,37 @@
+sasl_mechanism: SCRAM-SHA-256
+
+# set this false to switch to deleting
+acl_user_create: true
+
+# set this to true to delete users
+delete_users: false
+
+# set this to true to delete permissions
+delete_permissions: false
+
+# don't do this in production. run with these in the CLI and passed in by the environment. this is purely for CI convenience
+sasl_admin_username: admin
+sasl_admin_password: password
+
+# these are split into create and delete maps for safety reasons. if you want something deleted add it to the delete map
+user_password_map_create:
+  fizz:
+    password: "buzz"
+    permissions: "--operation all --topic '*' --group '*'"
+  foo:
+    password: "bar"
+    permissions: "--operation all --topic '*' --group '*'"
+  boom:
+    password: "bam"
+    permissions: "--operation all --topic '*' --group '*'"
+
+user_password_map_delete:
+  fizz:
+    password: "buzz"
+    permissions: "--operation all --topic '*' --group '*'"
+  foo:
+    password: "bar"
+    permissions: "--operation all --topic '*' --group '*'"
+  boom:
+    password: "bam"
+    permissions: "--operation all --topic '*' --group '*'"

--- a/roles/user_config/defaults/main.yml
+++ b/roles/user_config/defaults/main.yml
@@ -13,7 +13,10 @@ delete_permissions: false
 sasl_admin_username: admin
 sasl_admin_password: password
 
-# these are split into create and delete maps for safety reasons. if you want something deleted add it to the delete map
+# you can override this with a base64 encoded JSON object passed in through the command line
+# using the variable base64_encoded_up_map_create
+# this will allow password passthrough in a safer manner
+# make sure to not include whitespace in the JSON object
 user_password_map_create:
   fizz:
     password: "buzz"
@@ -28,6 +31,10 @@ user_password_map_create:
     permissions: "--operation all --topic '*' --group '*'"
     operation: "--allow-principal"
 
+# you can override this with a base64 encoded JSON object passed in through the command line
+# using the variable base64_encoded_up_map_delete
+# this will allow password passthrough in a safer manner
+# make sure to not include whitespace in the JSON object
 user_password_map_delete:
   fizz:
     password: "buzz"

--- a/roles/user_config/tasks/main.yml
+++ b/roles/user_config/tasks/main.yml
@@ -1,0 +1,33 @@
+# purpose : adds support for creating SASL users and ACLs
+
+# this should be passed through safely on the CLI not stored in plaintext
+- name: Create ACL Users
+  ansible.builtin.command:
+    cmd: "rpk acl user create {{ item.key }} -p {{ item.value.password }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ user_password_map_create | dict2items }}"
+  when:
+    - acl_user_create
+
+- name: Create acl-user linkages
+  ansible.builtin.command:
+    cmd: "rpk acl create --allow-principal User:{{ item.key }} {{ item.value.permissions }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ user_password_map_create | dict2items }}"
+  when:
+    - acl_user_create
+
+- name: Delete acl-user linkages
+  ansible.builtin.command:
+    cmd: "rpk acl delete --allow-principal User:{{ item.key }} {{ item.value.permissions }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ user_password_map_delete | dict2items }}"
+  when:
+    - not acl_user_create
+    - delete_permissions
+
+# this should be passed through safely on the CLI not stored in plaintext
+- name: Delete ACL Users
+  ansible.builtin.command:
+    cmd: "rpk acl user delete {{ item.key }} -p {{ item.value.password }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ user_password_map_delete | dict2items }}"
+  when:
+    - not acl_user_create
+    - delete_users

--- a/roles/user_config/tasks/main.yml
+++ b/roles/user_config/tasks/main.yml
@@ -1,24 +1,49 @@
 # purpose : adds support for creating SASL users and ACLs
 
+- name: Decode Base64 and Parse JSON if base64_encoded_up_map_create is defined and not empty
+  set_fact:
+    evaluated_user_password_map_create: "{{ (base64_encoded_up_map_create | b64decode | from_json) }}"
+  when:
+    - base64_encoded_up_map_create is defined
+
+- name: Decode Base64 and Parse JSON if base64_encoded_up_map_delete is defined and not empty
+  set_fact:
+    evaluated_user_password_map_delete: "{{ (base64_encoded_up_map_delete | b64decode | from_json) }}"
+  when:
+    - base64_encoded_up_map_delete is defined
+
+- name: Use user_password_map_create if base64_encoded_up_map_create is not defined or empty
+  set_fact:
+    evaluated_user_password_map_create: "{{ user_password_map_create }}"
+  when: base64_encoded_up_map_create is not defined
+
+- name: Use user_password_map_delete if base64_encoded_up_map_delete is not defined or empty
+  set_fact:
+    evaluated_user_password_map_delete: "{{ user_password_map_delete }}"
+  when: base64_encoded_up_map_delete is not defined
+
 # this should be passed through safely on the CLI not stored in plaintext
 - name: Create ACL Users
   ansible.builtin.command:
     cmd: "rpk acl user create {{ item.key }} -p {{ item.value.password }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
-  loop: "{{ user_password_map_create | dict2items }}"
+  loop: "{{ evaluated_user_password_map_create | dict2items }}"
+  run_once: true
   when:
     - acl_user_create
 
 - name: Create acl-user linkages
   ansible.builtin.command:
-    cmd: "rpk acl create --allow-principal User:{{ item.key }} {{ item.value.permissions }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
-  loop: "{{ user_password_map_create | dict2items }}"
+    cmd: "rpk acl create {{ item.value.operation }} User:{{ item.key }} {{ item.value.permissions }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ evaluated_user_password_map_create | dict2items }}"
+  run_once: true
   when:
     - acl_user_create
 
 - name: Delete acl-user linkages
   ansible.builtin.command:
-    cmd: "rpk acl delete --allow-principal User:{{ item.key }} {{ item.value.permissions }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
-  loop: "{{ user_password_map_delete | dict2items }}"
+    cmd: "rpk acl delete {{ item.value.operation }} User:{{ item.key }} {{ item.value.permissions }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ evaluated_user_password_map_create | dict2items }}"
+  run_once: true
   when:
     - not acl_user_create
     - delete_permissions
@@ -26,8 +51,9 @@
 # this should be passed through safely on the CLI not stored in plaintext
 - name: Delete ACL Users
   ansible.builtin.command:
-    cmd: "rpk acl user delete {{ item.key }} -p {{ item.value.password }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
-  loop: "{{ user_password_map_delete | dict2items }}"
+    cmd: "rpk acl user delete {{ item.key }} --user {{ sasl_admin_username }} --password {{ sasl_admin_password }} --sasl-mechanism {{ sasl_mechanism }}"
+  loop: "{{ evaluated_user_password_map_create | dict2items }}"
+  run_once: true
   when:
     - not acl_user_create
     - delete_users


### PR DESCRIPTION
Adds a SASL/ACL management role that supports various operations including creating and deleting users, creating and deleting ACLs and passing in maps for both of these purposes using a base64 encoded JSON object. 

Also adds various SASL config elements to enable the cluster to start with SASL including a bootstrap user file.

Finally, makes changes to the console config to support connecting with SASL to the Redpanda cluster. 

**REQUESTS FOR REVIEWERS**

Any suggestions on missing ACL operations or needs would be great. I'd like to improve that piece in particular. Thanks!