### PR TITLE
Add TLS to Console Front End.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.14
+version: 0.4.15
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -30,6 +30,11 @@ cloud_storage_enable_remote_write: "true"
 cloud_storage_enable_remote_read: "true"
 is_using_unstable: false
 
+# We default to use the same redpanda dirs, but in prod, a user can specify them directly
+console_certs_dir: "{{ redpanda_certs_dir }}"
+console_key_file: "{{ console_certs_dir }}/node.key"
+console_cert_file: "{{ console_certs_dir }}/node.crt"
+
 airgap_copy_src: "/tmp"
 airgap_copy_dest: "/tmp"
 

--- a/roles/redpanda_broker/templates/console/defaults.j2
+++ b/roles/redpanda_broker/templates/console/defaults.j2
@@ -12,7 +12,15 @@
         "http://{{ host }}:{{ redpanda_schema_registry_port }}"{% if not loop.last %},{% endif %}
         {% endfor %}
         {% endif %}
-      ]
+      ]{% if enable_tls | default(false) %},
+      "tls": {
+        "enabled": true,
+        "caFilepath": "{{ redpanda_truststore_file }}",
+        "certFilepath": "{{ redpanda_cert_file }}",
+        "keyFilepath": "{{ redpanda_key_file }}",
+        "insecureSkipTlsVerify": false
+      }
+      {% endif %}
     },
     "protobuf": {
       "enabled": true,

--- a/roles/redpanda_broker/templates/console/defaults.j2
+++ b/roles/redpanda_broker/templates/console/defaults.j2
@@ -66,5 +66,15 @@
       }
       {% endif %}
     }
+  }{% if enable_tls | default(false) %},
+  "server": {
+    "listenPort": 8080,
+    "httpsListenPort": 8081,
+    "tls": {
+      "enabled": true,
+      "certFilepath": "{{ console_cert_file }}",
+      "keyFilepath": "{{ console_key_file }}",
+    }
   }
+  {% endif %}
 }


### PR DESCRIPTION
This PR introduces a new set of variables to the Ansible collection:

- console_certs_dir
- console_key_file
- console_cert_file

Those are the paths either to the dir or to the key and cert file for the console front end.

The user can either use our certs creation (not recommended) or provide their own certs in the cluster and client (as [shown here](https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment-automation/#build-the-cluster-with-tls-enabled) in the docs)

```
ansible-playbook ansible/provision-tls-cluster.yml \
--private-key '<path-to-a-private-key-with-ssh-access-to-the-hosts>' \
--extra-vars create_demo_certs=false \
--extra-vars advertise_public_ips=false \
--extra-vars handle_certs=false \
--extra-vars redpanda_truststore_file='<path-to-ca.crt-file>'
--extra-vars console_key_file='<path-to.key-file>'
--extra-vars console_cert_file='<path-to.crt-file>'
```