### PR TITLE
Fix handling of empty rack id.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.15
+version: 0.4.16
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -35,6 +35,7 @@
           "port": "{{ redpanda_admin_api_port }}"
         }
       ],
+      {% if rack is defined and rack != ''  %}"rack": "{{ rack | default('null') }},"{% endif %}
       "seed_servers": [
         {% for host in groups['redpanda'] %}
         {
@@ -45,7 +46,6 @@
         }{% if not loop.last %},{% endif %}
         {% endfor %}
       ],
-      "rack": "{% if rack is defined %}{{ rack | default('null') }}{% endif %}"
     },
     "rpk": {
       "kafka_api": {

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -35,7 +35,7 @@
           "port": "{{ redpanda_admin_api_port }}"
         }
       ],
-      {% if rack is defined and rack != ''  %}"rack": "{{ rack | default('null') }},"{% endif %}
+      {% if rack is defined and rack != ''  %}"rack": "{{ rack | default('null') }}",{% endif %}
       "seed_servers": [
         {% for host in groups['redpanda'] %}
         {


### PR DESCRIPTION
Empty rack id could still cause rack: config to show up in json data structure. this ends up allowing an empty rack name to show up in the redpanda.yaml, causing follower fetching to enable even if rack awareness is turned off explicitly. This appears to cause some strange behavior with _schema topic and Schema Registry, making it throw 50002 errors.