### PR TITLE
Added - Copy Node Keys task block

### DIFF
--- a/roles/redpanda_broker/tasks/install-certs.yml
+++ b/roles/redpanda_broker/tasks/install-certs.yml
@@ -38,6 +38,17 @@
     force: "{{ overwrite_certs | default('no') | bool }}"
     mode: "0644"
 
+- name: Install_certs - Copy Node Keys
+  tags:
+    - install_certs
+  ansible.builtin.copy:
+    src: "{{ node_key_file }}"
+    dest: "{{ redpanda_key_file }}"
+    owner: redpanda
+    group: redpanda
+    force: "{{ overwrite_certs | default('no') | bool }}"
+    mode: "0644"
+
 - name: Install_certs - Set Redpanda config
   tags:
     - install_certs


### PR DESCRIPTION
I have added the code for issue 210 when demo certs is false and handle install is true, redpanda_key_file should be copied onto server. Please test and approve it thanks.