### PR TITLE
Bump inotify max_user_instances default

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.20
+version: 0.4.21
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/sysctl_setup/defaults/main.yml
+++ b/roles/sysctl_setup/defaults/main.yml
@@ -1,1 +1,8 @@
-max_user_instances: 512
+# inotify.max_user_instances caps the number of inotify watches a specific user
+# is allowed to create in Linux. In some larger setups, Redpanda may need to create
+# more. If this is set too low (like 512), it could manifest as odd behavior in
+# Schema Registry. 
+#
+# Adjust upwards as necessary. An upper limit has not been established. Increasing
+# this excessively can increase kernel memory usage. 
+max_user_instances: 8192


### PR DESCRIPTION
to better accommodate larger Redpanda setups. This appears to fix issues with inconsistent connectivity to Schema Registry.