### PR TITLE
[bug]: fix jinja template error

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.25
+version: 0.4.26
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/roles/redpanda_broker/templates/configs/defaults.j2
@@ -74,7 +74,7 @@
       "tune_ballast_file": {{ enable_tune_ballast_file | default(true) }}
     },
     "pandaproxy": {
-        "pandaproxy_api": [
+        "pandaproxy_api": {
           "address": "0.0.0.0",
           "port": "{{ redpanda_pandaproxy_port }}"
         }


### PR DESCRIPTION
panda proxy API was started with '[' instead of '{'.