### PR TITLE
Implemented fix for upgrades to RPM/Debian packages not registering the `package_result` variable causing upgrades not to trigger a restart.

### DIFF
--- a/roles/redpanda_broker/tasks/install-rp-deb.yml
+++ b/roles/redpanda_broker/tasks/install-rp-deb.yml
@@ -8,37 +8,17 @@
   ansible.builtin.set_fact:
     redpanda_package_name: "redpanda{{ '' if redpanda_version=='latest' else ('=' if ansible_os_family == 'Debian' else '-') + redpanda_version }}"
 
-- name: Install redpanda from repository (Proxy)
+- name: Install redpanda from repository
   ansible.builtin.package:
     name:
       - "{{ redpanda_package_name }}"
     state: "{{ redpanda_install_status }}"
     update_cache: true
+    allow_unauthenticated: "{{ using_gcp | default(false) }}"
   environment:
     https_proxy: "{{ https_proxy_value | default('') }}"
     http_proxy: "{{ https_proxy_value | default('') }}"
-  when:
-    - https_proxy_value is defined
-    - https_proxy_value | length > 0
-    - (using_gcp | default(false)) is false
-
-- name: Install redpanda from repository (Standard)
-  ansible.builtin.package:
-    name:
-      - "{{ redpanda_package_name }}"
-    state: "{{ redpanda_install_status }}"
-    update_cache: true
-  when: https_proxy_value is not defined and (using_gcp | default(false)) is false
-
-- name: Install redpanda from repository (GCP)
-  ansible.builtin.package:
-    name:
-      - "{{ redpanda_package_name }}"
-    state: "{{ redpanda_install_status }}"
-    update_cache: true
-    allow_unauthenticated: true
-  when: (using_gcp | default(false)) is not false
-
+  register: package_result
 
 - name: Set data dir file perms
   ansible.builtin.file:

--- a/roles/redpanda_broker/tasks/install-rp-rpm.yml
+++ b/roles/redpanda_broker/tasks/install-rp-rpm.yml
@@ -9,6 +9,7 @@
       - "{{ redpanda_package_name }}"
     state: "{{ redpanda_install_status }}"
     update_cache: true
+  register: package_result
 
 - name: Set data dir file perms
   ansible.builtin.file:


### PR DESCRIPTION
In testing #100 is appears that `register` still registers a result even if the `when` clause evaluates to `false`.

Explaining this change:
We currently have three `package` commands which do the same thing except controlled by the setting of three variables:

`Install redpanda from repository (Proxy)` is executed when:
```
- https_proxy_value is defined
- https_proxy_value | length > 0
 - (using_gcp | default(false)) is false
 ```

`Install redpanda from repository (Standard)` is executed when `https_proxy_value is not defined and (using_gcp | default(false)) is false`

`Install redpanda from repository (GCP)` is executed when `(using_gcp | default(false)) is not false`.

This can be summarised as:

|https_proxy | using_gcp| Task | 
| ----- | -----------| ----------- |
| unset (or `''`) | `false` or unset | Install redpanda from repository |
| unset (or `''`) | `true` | Install redpanda from repository (GCP) |
| set | `false` |  Install redpanda from repository (Proxy) |
| set | `true` | Install redpanda from repository (GCP) - possible bug, ignoring proxy settings? |

However when we look at the differences between the three tasks:
**Install redpanda from repository (Proxy)** - just sets environment variables `https_proxy` and `http_proxy`
**Install redpanda from repository (GCP)** - just sets `allow_unauthenticated: true`

So the basis of this change is:

Set `allow_unauthenticated` to `(using_gcp | default(false))`
Set `https_proxy` and `http_proxy` environment variables to the value of `https_proxy` if it's set (need to verify that setting these to `''` won't cause an issue - tested and it doesn't).

This also has the side effect of if `using_gcp` is `true` and `https_proxy` is set then we can use the proxy variables and use the `allow_unauthenticated` flag, which seems like the desired behaviour but currently doesn't not happen.

Plus we end up reducing the required setting of `register: package_result` to just once, which is what we needed.

Tested that installs and upgrades work without proxy settings.