### PR TITLE
Fix: properly handle passing redpanda variable in the hosts file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.28
+version: 0.4.29
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -28,43 +28,48 @@
     loop_var: custom_config_template
   when: custom_config_template.condition | default(True)
 
-# Print the redpanda variable when -vvv is specified - hint, this is often malformed due to the difficulty in passing it in on the command line
-- name: Debug
+- name: Debug redpanda variable
   ansible.builtin.debug:
     var: redpanda
     verbosity: 3
   when: redpanda is defined
 
-- name: Debug
-  ansible.builtin.debug:
-    msg: "{{ redpanda | from_json }}"
-    verbosity: 3
+- name: Parse redpanda variable
+  ansible.builtin.set_fact:
+    parsed_redpanda: "{{ redpanda if (redpanda is mapping) else (redpanda | from_json) }}"
   when: redpanda is defined
 
-# merge in user's overrides of items in the templates
-- name: Merge with user-provided overrides (via redpanda variable)
+- name: Set default empty dict if redpanda is not defined
   ansible.builtin.set_fact:
-    configuration: "{{ configuration | combine((redpanda | default('{}') | from_json), recursive=True) }}"
+    parsed_redpanda: {}
+  when: redpanda is not defined
 
-# Print the host_specific_override variable when -vvv is specified - hint, this is often malformed due to the difficulty in passing it in on the command line
-- name: Debug
+- name: Debug parsed redpanda
+  ansible.builtin.debug:
+    var: parsed_redpanda
+
+- name: Debug host_specific_override variable
   ansible.builtin.debug:
     var: host_specific_override
-    verbosity: 3
-  when: redpanda is defined
+  when: host_specific_override is defined
 
-- name: Debug
-  ansible.builtin.debug:
-    msg: "{{ host_specific_override | from_json }}"
-    verbosity: 3
-  when: redpanda is defined
-
-# merge in user's overrides of items in the templates
-- name: Merge with user-provided host specific overrides (via host_specific_override variable)
+- name: Set default empty dict if host_specific_override is not defined
   ansible.builtin.set_fact:
-    configuration: "{{ configuration | combine((host_specific_override | default('{}') | from_json), recursive=True) }}"
+    host_specific_override: {}
+  when: host_specific_override is not defined
 
-# on first startup, the redpanda process will create this directory and
+- name: Debug parsed host_specific_override
+  ansible.builtin.debug:
+    var: host_specific_override
+
+- name: Merge with user-provided overrides (via redpanda variable)
+  ansible.builtin.set_fact:
+    configuration: "{{ configuration | combine(parsed_redpanda, recursive=True) }}"
+
+- name: Merge with user-provided host specific overrides
+  ansible.builtin.set_fact:
+    configuration: "{{ configuration | combine(host_specific_override, recursive=True) }}"
+    # on first startup, the redpanda process will create this directory and
 # populate.  we need to use this as a trigger to restart redpanda after
 # bootstrapping the first time.
 #


### PR DESCRIPTION
The current implementation did not handle passing redpanda through the hosts file and would throw an error

```
TASK [redpanda.cluster.redpanda_broker : Merge with user-provided host specific overrides (via host_specific_override variable)] ****************************************************************
task path: /root/.ansible/collections/ansible_collections/redpanda/cluster/roles/redpanda_broker/tasks/start-redpanda.yml:63
fatal: [node-a]: FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ configuration | combine((host_specific_override | default('{}') | from_json), recursive=True) }}): the JSON object must be str, bytes or bytearray, not dict. the JSON object must be str, bytes or bytearray, not dict"
}
fatal: [node-b]: FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ configuration | combine((host_specific_override | default('{}') | from_json), recursive=True) }}): the JSON object must be str, bytes or bytearray, not dict. the JSON object must be str, bytes or bytearray, not dict"
}
fatal: [node-c]: FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ configuration | combine((host_specific_override | default('{}') | from_json), recursive=True) }}): the JSON object must be str, bytes or bytearray, not dict. the JSON object must be str, bytes or bytearray, not dict"
}
```

This occurs because Ansible automatically converts the supplied JSON object into a dict when it is passed through the hosts file but requires manual conversion when passed as a string through the command line. 

First test was with this host file and command:

```
.PHONY: cluster
cluster: ansible-prereqs
	@mkdir -p $(ARTIFACT_DIR)/logs
	@ansible-playbook ansible/provision-cluster.yml -vvv --private-key $(PRIVATE_KEY) --inventory $(ANSIBLE_INVENTORY) --extra-vars is_using_unstable=$(IS_USING_UNSTABLE) --extra-vars redpanda_version=$(REDPANDA_VERSION) --extra-vars redpanda_install_status=$(REDPANDA_INSTALL_STATUS)
```

```
[all:vars]
redpanda={"node":{"redpanda":{"kafka_api":[{"address":"0.0.0.0","port":9092,"name":"test1"},{"address":"0.0.0.0","port":9093,"name":"test2"},{"address":"0.0.0.0","port":9094,"name":"test3"}]}}}

[redpanda]
35.87.209.252 ansible_user=ubuntu ansible_become=True private_ip=172.31.32.209 host_specific_override='{"node":{"redpanda":{"advertised_kafka_api":[{"address":"35.87.209.252","port":9092,"name":"test1"},{"address":"35.87.209.252","port":9093,"name":"test2"}]}}}'
34.219.230.84 ansible_user=ubuntu ansible_become=True private_ip=172.31.34.100 host_specific_override='{"node":{"redpanda":{"advertised_kafka_api":[{"address":"34.219.230.84","port":9092,"name":"test1"},{"address":"34.219.230.84","port":9093,"name":"test2"}]}}}'
34.213.178.226 ansible_user=ubuntu ansible_become=True private_ip=172.31.33.139 host_specific_override='{"node":{"redpanda":{"advertised_kafka_api":[{"address":"34.213.178.226","port":9092,"name":"test1"},{"address":"34.213.178.226","port":9093,"name":"test2"}]}}}'

[monitor]
52.40.46.171 ansible_user=ubuntu ansible_become=True private_ip=172.31.17.57

[client]
54.218.124.0 ansible_user=ubuntu ansible_become=True private_ip=172.31.18.19 id=0
```

Second test was with this host file and command

```
.PHONY: cluster-rp
cluster-rp: ansible-prereqs
	@mkdir -p $(ARTIFACT_DIR)/logs
	@ansible-playbook ansible/provision-cluster.yml -vvv --private-key $(PRIVATE_KEY) --inventory $(ANSIBLE_INVENTORY) --extra-vars is_using_unstable=$(IS_USING_UNSTABLE) --extra-vars redpanda_version=$(REDPANDA_VERSION) --extra-vars redpanda_install_status=$(REDPANDA_INSTALL_STATUS) --extra-vars redpanda='{"node":{"redpanda":{"kafka_api":[{"address":"0.0.0.0","port":9092,"name":"test1"},{"address":"0.0.0.0","port":9093,"name":"test2"},{"address":"0.0.0.0","port":9094,"name":"test3"}]}}}'
```

```
[redpanda]
35.87.209.252 ansible_user=ubuntu ansible_become=True private_ip=172.31.32.209 host_specific_override='{"node":{"redpanda":{"advertised_kafka_api":[{"address":"35.87.209.252","port":9092,"name":"test1"},{"address":"35.87.209.252","port":9093,"name":"test2"}]}}}'
34.219.230.84 ansible_user=ubuntu ansible_become=True private_ip=172.31.34.100 host_specific_override='{"node":{"redpanda":{"advertised_kafka_api":[{"address":"34.219.230.84","port":9092,"name":"test1"},{"address":"34.219.230.84","port":9093,"name":"test2"}]}}}'
34.213.178.226 ansible_user=ubuntu ansible_become=True private_ip=172.31.33.139 host_specific_override='{"node":{"redpanda":{"advertised_kafka_api":[{"address":"34.213.178.226","port":9092,"name":"test1"},{"address":"34.213.178.226","port":9093,"name":"test2"}]}}}'

[monitor]
52.40.46.171 ansible_user=ubuntu ansible_become=True private_ip=172.31.17.57

[client]
54.218.124.0 ansible_user=ubuntu ansible_become=True private_ip=172.31.18.19 id=0
```

Redpanda.yml from first test
```
cluster_id: redpanda
organization: redpanda-test
pandaproxy:
    pandaproxy_api:
        address: 0.0.0.0
        port: '8082'
redpanda:
    admin:
    -   address: 172.31.33.139
        port: '9644'
    advertised_kafka_api:
    -   address: 34.213.178.226
        name: test1
        port: 9092
    -   address: 34.213.178.226
        name: test2
        port: 9093
    advertised_rpc_api:
        address: 172.31.33.139
        port: '33145'
    data_directory: /var/lib/redpanda/data
    empty_seed_starts_cluster: false
    kafka_api:
    -   address: 0.0.0.0
        name: test1
        port: 9092
    -   address: 0.0.0.0
        name: test2
        port: 9093
    rpc_server:
        address: 172.31.33.139
        port: '33145'
    seed_servers:
    -   host:
            address: 172.31.32.209
            port: '33145'
    -   host:
            address: 172.31.34.100
            port: '33145'
    -   host:
            address: 172.31.33.139
            port: '33145'
rpk:
    admin_api:
        addresses:
        - 172.31.32.209:9644
        - 172.31.34.100:9644
        - 172.31.33.139:9644
    kafka_api:
        brokers:
        - 172.31.32.209:9092
        - 172.31.34.100:9092
        - 172.31.33.139:9092
    tune_aio_events: true
    tune_ballast_file: true
    tune_clocksource: true
    tune_cpu: true
    tune_disk_irq: true
    tune_disk_nomerges: true
    tune_disk_scheduler: true
    tune_disk_write_cache: true
    tune_network: true
    tune_swappiness: true
schema_registry:
    schema_registry_api:
    -   address: 0.0.0.0
        port: '8081'
    schema_registry_replication_factor: 1
 ```
 
 Redpanda.yml from second test
 
 ```
 cluster_id: redpanda
organization: redpanda-test
pandaproxy:
    pandaproxy_api:
        address: 0.0.0.0
        port: '8082'
redpanda:
    admin:
    -   address: 172.31.33.139
        port: '9644'
    advertised_kafka_api:
    -   address: 34.213.178.226
        name: test1
        port: 9092
    -   address: 34.213.178.226
        name: test2
        port: 9093
    advertised_rpc_api:
        address: 172.31.33.139
        port: '33145'
    data_directory: /var/lib/redpanda/data
    empty_seed_starts_cluster: false
    kafka_api:
    -   address: 0.0.0.0
        name: test1
        port: 9092
    -   address: 0.0.0.0
        name: test2
        port: 9093
    -   address: 0.0.0.0
        name: test3
        port: 9094
    rpc_server:
        address: 172.31.33.139
        port: '33145'
    seed_servers:
    -   host:
            address: 172.31.32.209
            port: '33145'
    -   host:
            address: 172.31.34.100
            port: '33145'
    -   host:
            address: 172.31.33.139
            port: '33145'
rpk:
    admin_api:
        addresses:
        - 172.31.32.209:9644
        - 172.31.34.100:9644
        - 172.31.33.139:9644
    kafka_api:
        brokers:
        - 172.31.32.209:9092
        - 172.31.34.100:9092
        - 172.31.33.139:9092
    tune_aio_events: true
    tune_ballast_file: true
    tune_clocksource: true
    tune_cpu: true
    tune_disk_irq: true
    tune_disk_nomerges: true
    tune_disk_scheduler: true
    tune_disk_write_cache: true
    tune_network: true
    tune_swappiness: true
schema_registry:
    schema_registry_api:
    -   address: 0.0.0.0
        port: '8081'
    schema_registry_replication_factor: 1
```

Both tests were also validated with topic creation, produce and consume.