### PR TITLE
feat: add require_client_auth to tls for mtls

### DIFF
--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -9,6 +9,7 @@ redpanda_kafka_port: 9092
 redpanda_rpc_port: 33145
 redpanda_schema_registry_port: 8081
 redpanda_pandaproxy_port: 8082
+require_client_auth: false
 
 redpanda_use_staging_repo: false
 redpanda_base_url: "https://dl.redpanda.com"

--- a/roles/redpanda_broker/templates/configs/tls.j2
+++ b/roles/redpanda_broker/templates/configs/tls.j2
@@ -3,21 +3,21 @@
     "redpanda": {
       "admin_api_tls": {
         "enabled": true,
-        "require_client_auth": false,
+        "require_client_auth": {{ require_client_auth }},
         "key_file": "{{ redpanda_key_file }}",
         "cert_file": "{{ redpanda_cert_file }}",
         "truststore_file": "{{ redpanda_truststore_file }}"
       },
       "kafka_api_tls": {
         "enabled": true,
-        "require_client_auth": false,
+        "require_client_auth": {{ require_client_auth }},
         "key_file": "{{ redpanda_key_file }}",
         "cert_file": "{{ redpanda_cert_file }}",
         "truststore_file": "{{ redpanda_truststore_file }}"
       },
       "rpc_server_tls": {
         "enabled": true,
-        "require_client_auth": false,
+        "require_client_auth": {{ require_client_auth }},
         "key_file": "{{ redpanda_key_file }}",
         "cert_file": "{{ redpanda_cert_file }}",
         "truststore_file": "{{ redpanda_truststore_file }}"
@@ -39,7 +39,7 @@
       "pandaproxy_api_tls": [
         {
           "enabled": true,
-          "require_client_auth": false,
+          "require_client_auth": {{ require_client_auth }},
           "key_file": "{{ redpanda_key_file }}",
           "cert_file": "{{ redpanda_cert_file }}",
           "truststore_file": "{{ redpanda_truststore_file }}"
@@ -50,7 +50,7 @@
       "schema_registry_api_tls": [
         {
           "enabled": true,
-          "require_client_auth": false,
+          "require_client_auth": {{ require_client_auth }},
           "key_file": "{{ redpanda_key_file }}",
           "cert_file": "{{ redpanda_cert_file }}",
           "truststore_file": "{{ redpanda_truststore_file }}"

--- a/roles/redpanda_broker/tests/tls_test.py
+++ b/roles/redpanda_broker/tests/tls_test.py
@@ -1,27 +1,37 @@
 import unittest
 import os
 import yaml
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, Undefined
+
+class RecursiveUndefined(Undefined):
+    def __getattr__(self, name):
+        if name == 'undefined_name':
+            return self._undefined_name
+        return RecursiveUndefined(name=f'{self._undefined_name}.{name}')
+
+    def __str__(self):
+        return '{{ %s }}' % self._undefined_name
 
 class TestRedpandaTemplate(unittest.TestCase):
     def setUp(self):
-        # Get the absolute path of the current file
         self.current_dir = os.path.dirname(os.path.abspath(__file__))
-
-        # Construct the path to the templates directory
         self.templates_dir = os.path.join(self.current_dir, '..', 'templates/configs')
-
-        # Construct the path to the defaults/main.yml file
         self.defaults_file = os.path.join(self.current_dir, '..', 'defaults', 'main.yml')
 
         # Load the defaults from the YAML file
         with open(self.defaults_file, 'r') as f:
             self.defaults = yaml.safe_load(f)
 
-        # Create a Jinja2 environment
-        self.env = Environment(loader=FileSystemLoader(self.templates_dir))
+        # Create a Jinja2 environment with recursive undefined handling
+        self.env = Environment(
+            loader=FileSystemLoader(self.templates_dir),
+            undefined=RecursiveUndefined
+        )
 
-        # Define the hostvars and groups for rendering the template
+        # Add a custom filter for recursive rendering
+        self.env.filters['recursive_render'] = self.recursive_render
+
+        self.maxDiff = None
         self.hostvars = {
             '35.91.106.231': {
                 'ansible_host': '35.91.106.231',
@@ -43,60 +53,58 @@ class TestRedpandaTemplate(unittest.TestCase):
             'redpanda': ['35.91.106.231', '35.88.129.205', '54.190.184.126']
         }
 
+    def recursive_render(self, template_string):
+        template = self.env.from_string(template_string)
+        return template.render(**self.defaults)
+
     def test_redpanda_template_tls(self):
-        # Load the template from file
         template = self.env.get_template('tls.j2')
 
-        # Define the variables for the template
-        context = {
-            'redpanda_key_file': '/etc/redpanda/tls/key.pem',
-            'redpanda_cert_file': '/etc/redpanda/tls/cert.pem',
-            'redpanda_truststore_file': '/etc/redpanda/tls/truststore.pem'
-        }
-
-        # Render the template with the provided variables, hostvars, and groups
-        rendered_template = template.render(
+        # First pass: render the template
+        first_pass = template.render(
             hostvars=self.hostvars,
             groups=self.groups,
             inventory_hostname='35.91.106.231',
-            **context
+            **self.defaults
         )
 
-        # Define the expected rendered values
+        # Second pass: resolve any remaining Jinja2 expressions
+        rendered_template = self.env.from_string(first_pass).render(**self.defaults)
+
         expected_rendered_values = {
             "node": {
                 "redpanda": {
                     "admin_api_tls": {
                         "enabled": True,
                         "require_client_auth": False,
-                        "key_file": "/etc/redpanda/tls/key.pem",
-                        "cert_file": "/etc/redpanda/tls/cert.pem",
-                        "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                        "key_file": "/etc/redpanda/certs/node.key",
+                        "cert_file": "/etc/redpanda/certs/node.crt",
+                        "truststore_file": "/etc/redpanda/certs/truststore.pem"
                     },
                     "kafka_api_tls": {
                         "enabled": True,
                         "require_client_auth": False,
-                        "key_file": "/etc/redpanda/tls/key.pem",
-                        "cert_file": "/etc/redpanda/tls/cert.pem",
-                        "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                        "key_file": "/etc/redpanda/certs/node.key",
+                        "cert_file": "/etc/redpanda/certs/node.crt",
+                        "truststore_file": "/etc/redpanda/certs/truststore.pem"
                     },
                     "rpc_server_tls": {
                         "enabled": True,
                         "require_client_auth": False,
-                        "key_file": "/etc/redpanda/tls/key.pem",
-                        "cert_file": "/etc/redpanda/tls/cert.pem",
-                        "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                        "key_file": "/etc/redpanda/certs/node.key",
+                        "cert_file": "/etc/redpanda/certs/node.crt",
+                        "truststore_file": "/etc/redpanda/certs/truststore.pem"
                     }
                 },
                 "rpk": {
                     "admin_api": {
                         "tls": {
-                            "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                            "truststore_file": "/etc/redpanda/certs/truststore.pem"
                         }
                     },
                     "kafka_api": {
                         "tls": {
-                            "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                            "truststore_file": "/etc/redpanda/certs/truststore.pem"
                         }
                     }
                 },
@@ -105,9 +113,9 @@ class TestRedpandaTemplate(unittest.TestCase):
                         {
                             "enabled": True,
                             "require_client_auth": False,
-                            "key_file": "/etc/redpanda/tls/key.pem",
-                            "cert_file": "/etc/redpanda/tls/cert.pem",
-                            "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                            "key_file": "/etc/redpanda/certs/node.key",
+                            "cert_file": "/etc/redpanda/certs/node.crt",
+                            "truststore_file": "/etc/redpanda/certs/truststore.pem"
                         }
                     ]
                 },
@@ -116,19 +124,16 @@ class TestRedpandaTemplate(unittest.TestCase):
                         {
                             "enabled": True,
                             "require_client_auth": False,
-                            "key_file": "/etc/redpanda/tls/key.pem",
-                            "cert_file": "/etc/redpanda/tls/cert.pem",
-                            "truststore_file": "/etc/redpanda/tls/truststore.pem"
+                            "key_file": "/etc/redpanda/certs/node.key",
+                            "cert_file": "/etc/redpanda/certs/node.crt",
+                            "truststore_file": "/etc/redpanda/certs/truststore.pem"
                         }
                     ]
                 }
             }
         }
 
-        # Convert the rendered template to a dictionary for easier comparison
         rendered_dict = yaml.safe_load(rendered_template)
-
-        # Assert that the expected values are in the rendered template
         self.assertEqual(rendered_dict, expected_rendered_values)
 
         print(rendered_template)


### PR DESCRIPTION
This adds require_client_auth which will hopefully enable mtls support.

It also fixes the template test by guaranteeing it pulls from the defaults file. This caused a new issue: the test was not rendering the daisy chained variables in the defaults file. I fixed that by rendering the file twice and hitting it with some recursion just in case. 

I believe the technical term for this is "nuke it from orbit, it's the only way to be sure"