### PR TITLE
fix: remove bad checks

### DIFF
--- a/roles/redpanda_broker/tasks/install-certs.yml
+++ b/roles/redpanda_broker/tasks/install-certs.yml
@@ -50,5 +50,3 @@
     mode: "0644"
   when:
     - not (node_key_file | default('') == '')
-    - handle_cert_install | default(false) | bool
-    - not (create_demo_certs | default(false) | bool)


### PR DESCRIPTION
These checks are improperly stopping task execution when they're trying to use the role to copy their certs without having it generate them.