### PR TITLE
Add nightly build support

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.6.1
+version: 0.6.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/demo_certs/defaults/main.yml
+++ b/roles/demo_certs/defaults/main.yml
@@ -13,3 +13,5 @@ redpanda_truststores_dir: /etc/redpanda/truststores
 truststore_type: PKCS12
 keystore_file_name: keystore.p12
 keystores_type: PKCS12
+redpanda_user: redpanda
+redpanda_group: redpanda

--- a/roles/demo_certs/tasks/generate-csrs-keystore.yml
+++ b/roles/demo_certs/tasks/generate-csrs-keystore.yml
@@ -9,12 +9,24 @@
       - "ansible_hostname: {{ hostvars[inventory_hostname]['ansible_hostname'] }}"
       - "ansible_fqdn    : {{ hostvars[inventory_hostname]['ansible_fqdn'] }}"
 
+- name: Create redpanda group
+  ansible.builtin.group:
+    name: "{{ redpanda_group }}"
+    state: present
+    system: true
+  become: true
+
 - name: Create redpanda user if it doesn't exist already
   tags:
     - generate_csrs_keystore
   ansible.builtin.user:
-    name: redpanda
+    name: "{{ redpanda_user }}"
+    group: "{{ redpanda_group }}"
     system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    state: present
+  become: true
 
 - name: Ensure /etc/redpanda/certs exists
   tags:

--- a/roles/demo_certs/tasks/generate-csrs.yml
+++ b/roles/demo_certs/tasks/generate-csrs.yml
@@ -9,12 +9,25 @@
       - "ansible_hostname: {{ hostvars[inventory_hostname]['ansible_hostname'] }}"
       - "ansible_fqdn    : {{ hostvars[inventory_hostname]['ansible_fqdn'] }}"
 
+- name: Create redpanda group
+  ansible.builtin.group:
+    name: "{{ redpanda_group }}"
+    state: present
+    system: true
+  become: true
+
+
 - name: Create redpanda user if it doesn't exist already
   tags:
     - generate_csrs
   ansible.builtin.user:
-    name: redpanda
+    name: "{{ redpanda_user }}"
+    group: "{{ redpanda_group }}"
     system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    state: present
+  become: true
 
 - name: Ensure /etc/redpanda/certs exists
   tags:

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -10,6 +10,8 @@ redpanda_rpc_port: 33145
 redpanda_schema_registry_port: 8081
 redpanda_pandaproxy_port: 8082
 require_client_auth: false
+redpanda_user: redpanda
+redpanda_group: redpanda
 
 redpanda_use_staging_repo: false
 redpanda_base_url: "https://dl.redpanda.com"

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -69,3 +69,10 @@ rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpan
 rp_repo_signing_src_deb_unstable: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
 
 redpanda_broker_no_log: true
+
+# used for installing the nightly build
+cloudsmith_token: "{{ lookup('env', 'CLOUDSMITH_API_KEY') }}"
+cloudsmith_gpg_key_url: "https://dl.redpanda.com/{{ cloudsmith_token }}/redpanda-nightly/gpg.E2242C4583FC4E52.key"
+cloudsmith_config_url: "https://dl.redpanda.com/{{ cloudsmith_token }}/redpanda-nightly/config.deb.txt"
+keyring_location: '/usr/share/keyrings/redpanda-redpanda-nightly-archive-keyring.gpg'
+development_build: false

--- a/roles/redpanda_broker/tasks/install-certs.yml
+++ b/roles/redpanda_broker/tasks/install-certs.yml
@@ -1,10 +1,25 @@
 ---
+- name: Create redpanda group
+  ansible.builtin.group:
+    name: "{{ redpanda_group }}"
+    state: present
+    system: true
+  become: true
+  tags:
+    - install_certs
+
+
 - name: Install certs - create redpanda user if it doesn't exist already
   tags:
     - install_certs
   ansible.builtin.user:
-    name: redpanda
+    name: "{{ redpanda_user }}"
+    group: "{{ redpanda_group }}"
     system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    state: present
+  become: true
 
 - name: Install certs - ensure /etc/redpanda/certs exists
   tags:

--- a/roles/redpanda_broker/tasks/install-nightly-build.yml
+++ b/roles/redpanda_broker/tasks/install-nightly-build.yml
@@ -1,0 +1,44 @@
+---
+- name: Set distribution-specific variables
+  set_fact:
+    distro: "{{ ansible_distribution | lower }}"
+    codename: "{{ ansible_distribution_release }}"
+    arch: "{{ ansible_architecture }}"
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install required packages
+  apt:
+    name:
+      - debian-keyring
+      - debian-archive-keyring
+      - apt-transport-https
+      - gnupg
+    state: present
+
+- name: Download Cloudsmith GPG key
+  get_url:
+    url: "{{ cloudsmith_gpg_key_url }}"
+    dest: /tmp/cloudsmith_gpg.key
+    mode: '0644'
+
+- name: Dearmor and add Cloudsmith GPG key
+  ansible.builtin.shell: gpg --dearmor < /tmp/cloudsmith_gpg.key > {{ keyring_location }}
+  args:
+    creates: "{{ keyring_location }}"
+  become: true
+
+- name: Set correct permissions for the keyring file
+  file:
+    path: "{{ keyring_location }}"
+    mode: '0644'
+  become: true
+
+- name: Add Cloudsmith repository configuration
+  get_url:
+    url: "{{ cloudsmith_config_url }}?distro={{ distro }}&codename={{ codename }}&arch={{ arch }}&component=main"
+    dest: /etc/apt/sources.list.d/redpanda-redpanda-nightly.list
+    mode: '0644'
+  become: true

--- a/roles/redpanda_broker/tasks/main.yml
+++ b/roles/redpanda_broker/tasks/main.yml
@@ -23,12 +23,21 @@
   when:
     - ansible_os_family == 'RedHat'
     - not (enable_airgap | bool)
+    - not (development_build | bool)
 
 - name: Configure Redpanda DEB Repository
   ansible.builtin.include_tasks: configure-deb-repository.yml
   when:
     - ansible_os_family == 'Debian'
     - not (enable_airgap | bool)
+    - not (development_build | bool)
+
+- name: Configure Redpanda DEB Repository Development
+  ansible.builtin.include_tasks: install-nightly-build.yml
+  when:
+    - ansible_os_family == 'Debian'
+    - not (enable_airgap | bool)
+    - development_build | bool
 
 - name: Install Redpanda RPM
   ansible.builtin.include_tasks: install-rp-rpm.yml

--- a/roles/redpanda_broker/tasks/safe-restart.yml
+++ b/roles/redpanda_broker/tasks/safe-restart.yml
@@ -10,7 +10,7 @@
   when:
     - restart_required
     - inventory_hostname == cluster_host
-    - ansible_play_hosts > 1
+    - ansible_play_hosts | length > 1
 
 # We need to (actually) generate the node config once the node is in MM, otherwise the `rpk cluster maintenance` command
 # will fail
@@ -41,4 +41,4 @@
   when:
     - restart_required
     - inventory_hostname == cluster_host
-    - ansible_play_hosts > 1
+    - ansible_play_hosts | length > 1

--- a/roles/redpanda_connect/defaults/main.yml
+++ b/roles/redpanda_connect/defaults/main.yml
@@ -101,3 +101,5 @@ redpanda_cert_file: "{{ redpanda_certs_dir }}/node.crt"
 redpanda_truststore_file: "{{ redpanda_certs_dir }}/truststore.pem"
 
 timeout_start_sec: 30
+redpanda_user: redpanda
+redpanda_group: redpanda

--- a/roles/redpanda_connect/tasks/install-certs.yml
+++ b/roles/redpanda_connect/tasks/install-certs.yml
@@ -1,10 +1,24 @@
 ---
+- name: Create redpanda group
+  ansible.builtin.group:
+    name: "{{ redpanda_group }}"
+    state: present
+    system: true
+  become: true
+  tags:
+    - install_certs
+
 - name: Create redpanda user if it doesn't exist already
   tags:
     - install_certs
   ansible.builtin.user:
-    name: redpanda
+    name: "{{ redpanda_user }}"
+    group: "{{ redpanda_group }}"
     system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    state: present
+  become: true
 
 - name: Ensure /etc/redpanda/certs exists
   tags:

--- a/roles/redpanda_console/tasks/install-certs.yml
+++ b/roles/redpanda_console/tasks/install-certs.yml
@@ -1,10 +1,24 @@
 ---
+- name: Create redpanda group
+  ansible.builtin.group:
+    name: "{{ redpanda_group }}"
+    state: present
+    system: true
+  become: true
+  tags:
+    - install_certs
+
 - name: Install certs - create redpanda user if it doesn't exist already
   tags:
     - install_certs
   ansible.builtin.user:
-    name: redpanda
+    name: "{{ redpanda_user }}"
+    group: "{{ redpanda_group }}"
     system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    state: present
+  become: true
 
 - name: Install certs - ensure /etc/redpanda/certs exists
   tags:


### PR DESCRIPTION
Currently we can only build against the release candidates which is usually enough but for testing features that are still being built using tiered storage this is very helpful. 

This PR also includes a security fix and a bugfix. 