### PR TITLE
RHEL-based OS support for deploying FIPS-enabled RP clusters 

### DIFF
--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -79,3 +79,20 @@ cloudsmith_config_url_deb: "https://dl.redpanda.com/{{ cloudsmith_token }}/redpa
 cloudsmith_config_url_rpm: "https://dl.redpanda.com/{{ cloudsmith_token }}/redpanda-nightly/config.rpm.txt"
 keyring_location: '/usr/share/keyrings/redpanda-redpanda-nightly-archive-keyring.gpg'
 development_build: false
+
+
+
+# enable fips. requires an enterprise license.
+# see https://docs.redpanda.com/current/manage/security/fips-compliance/
+enable_fips: false
+fips_mode: disabled
+fips_openssl_config_file: "/opt/redpanda/openssl/openssl.cnf"
+fips_openssl_module_directory: "/opt/redpanda/lib/ossl-modules/"
+
+
+# fips vars for checking status
+fips_check_exit_codes:
+  - 0  # fips-mode-setup is enabled
+  - 1  # fips-mode-setup is inconsistent
+  - 2  # fips-mode-setup is disabled
+fips_disabled_code: 2

--- a/roles/redpanda_broker/tasks/fips-assert.yml
+++ b/roles/redpanda_broker/tasks/fips-assert.yml
@@ -1,0 +1,18 @@
+---
+- name: Check OS FIPS mode with /usr/bin/fips-mode-setup
+  ansible.builtin.command:
+    cmd: /usr/bin/fips-mode-setup --is-enabled
+  register: os_fips_mode
+  when:
+    - ansible_os_family == "RedHat"
+  changed_when: false
+  failed_when:
+    - os_fips_mode.rc not in fips_check_exit_codes
+
+- name: Ensure FIPS not disabled"
+  ansible.builtin.assert:
+    that:
+      - os_fips_mode.rc == 2 and fips_mode != "enabled"
+    fail_msg: "OS does not have FIPS correctly enabled (fips-mode-setup exit code == {{os_fips_mode.rc}}) and Redpanda Ansible 'fips_mode' setting is possibly enabled (currently set to {{fips_mode}}); this will cause Redpanda startup failures. set fips_mode=permissive for unsafe bypass"
+
+# when: not (install_certs_only | default(false) | bool)

--- a/roles/redpanda_broker/tasks/fips-assert.yml
+++ b/roles/redpanda_broker/tasks/fips-assert.yml
@@ -15,4 +15,3 @@
       - os_fips_mode.rc == 2 and fips_mode != "enabled"
     fail_msg: "OS does not have FIPS correctly enabled (fips-mode-setup exit code == {{os_fips_mode.rc}}) and Redpanda Ansible 'fips_mode' setting is possibly enabled (currently set to {{fips_mode}}); this will cause Redpanda startup failures. set fips_mode=permissive for unsafe bypass"
 
-# when: not (install_certs_only | default(false) | bool)

--- a/roles/redpanda_broker/tasks/install-rp-rpm.yml
+++ b/roles/redpanda_broker/tasks/install-rp-rpm.yml
@@ -15,7 +15,7 @@
 
 - name: generate package list to install
   ansible.builtin.set_fact:
-    redpanda_package_list: "{{ ['redpanda-rpk-fips', 'redpanda', 'redpanda-fips', 'redpanda-tuner'] if enable_fips | bool else ['redpanda-rpk','redpanda','redpanda-tuners']  }}"
+    redpanda_package_list: "{{ ['redpanda-rpk-fips', 'redpanda', 'redpanda-fips', 'redpanda-tuner'] if enable_fips | bool else ['redpanda-rpk','redpanda','redpanda-tuner']  }}"
 
 - name: generate versioned package list to install
   ansible.builtin.set_fact:

--- a/roles/redpanda_broker/tasks/install-rp-rpm.yml
+++ b/roles/redpanda_broker/tasks/install-rp-rpm.yml
@@ -8,6 +8,19 @@
          development_build | default(false) | bool }}
     allow_lower_version: "{{ development_build | default(false) | bool }}"
 
+- name: check OS FIPS mode state to see if configured and safe for Redpanda to proceed with fips_mode=enabled
+  ansible.builtin.include_tasks: fips-assert.yml
+  when:
+   - enable_fips | default(false) | bool
+
+- name: generate package list to install
+  ansible.builtin.set_fact:
+    redpanda_package_list: "{{ ['redpanda-rpk-fips', 'redpanda', 'redpanda-fips', 'redpanda-tuner'] if enable_fips | bool else ['redpanda-rpk','redpanda','redpanda-tuners']  }}"
+
+- name: generate versioned package list to install
+  ansible.builtin.set_fact:
+    redpanda_package_list_versioned: "{{ redpanda_package_list | product([redpanda_version_suffix]) | map('join') | list }}"
+
 - name: Install redpanda (pre 24.2)
   dnf:
     name: "redpanda{{ redpanda_version_suffix }}"
@@ -20,15 +33,10 @@
   register: package_result
   when: not needs_split_packages
 
+
 - name: Install redpanda (post 24.2 or development)
   dnf:
-    name:
-      - "redpanda-rpk{{ '' if enable_fips == 'disabled' else '-fips'}}{{ redpanda_version_suffix }}"
-      - "redpanda{{ redpanda_version_suffix }}"
-      {% if enable_fips != 'disabled' %}
-      - "redpanda-fips{{ redpanda_version_suffix }}"
-      {% endif %}
-      - "redpanda-tuner{{ redpanda_version_suffix }}"
+    name: "{{item}}"
     state: "{{ redpanda_install_status }}"
     update_cache: true
     allow_downgrade: "{{ allow_lower_version }}"
@@ -37,6 +45,7 @@
     http_proxy: "{{ https_proxy_value | default('') }}"
   register: package_result
   when: needs_split_packages
+  loop: "{{ redpanda_package_list }}"
 
 - name: Set data dir file perms
   ansible.builtin.file:

--- a/roles/redpanda_broker/tasks/install-rp-rpm.yml
+++ b/roles/redpanda_broker/tasks/install-rp-rpm.yml
@@ -23,8 +23,11 @@
 - name: Install redpanda (post 24.2 or development)
   dnf:
     name:
+      - "redpanda-rpk{{ '' if enable_fips == 'disabled' else '-fips'}}{{ redpanda_version_suffix }}"
       - "redpanda{{ redpanda_version_suffix }}"
-      - "redpanda-rpk{{ redpanda_version_suffix }}"
+      {% if enable_fips != 'disabled' %}
+      - "redpanda-fips{{ redpanda_version_suffix }}"
+      {% endif %}
       - "redpanda-tuner{{ redpanda_version_suffix }}"
     state: "{{ redpanda_install_status }}"
     update_cache: true

--- a/roles/redpanda_broker/templates/configs/fips.j2
+++ b/roles/redpanda_broker/templates/configs/fips.j2
@@ -1,0 +1,9 @@
+{
+  "node": {
+    "redpanda": {
+      "fips_mode": "{{ fips_mode }}",
+      "openssl_config_file": "{{ fips_openssl_config_file }}",
+      "openssl_module_directory": "{{ fips_openssl_module_directory }}"
+   }
+ }
+}

--- a/roles/redpanda_broker/vars/main.yml
+++ b/roles/redpanda_broker/vars/main.yml
@@ -5,3 +5,5 @@ custom_config_templates:
     condition: "{{ enable_tls | default(False) | bool }}"
   - template: configs/tiered_storage.j2
     condition: "{{ tiered_storage_bucket_name is defined | default(False) | bool }}"
+  - template: configs/fips.j2
+    condition: "{{ enable_fips is defined | default(False) | bool}}"

--- a/roles/redpanda_broker/vars/main.yml
+++ b/roles/redpanda_broker/vars/main.yml
@@ -6,4 +6,4 @@ custom_config_templates:
   - template: configs/tiered_storage.j2
     condition: "{{ tiered_storage_bucket_name is defined | default(False) | bool }}"
   - template: configs/fips.j2
-    condition: "{{ enable_fips is defined | default(False) | bool}}"
+    condition: "{{ enable_fips | default(False) | bool}}"


### PR DESCRIPTION
Second attempt at getting automated fips installs, now working with the new consolidated package deployment mechanism for supporting 24.3 releases correctly. 

There are two variables to pay attention to:

1. enable_fips = true|false (default=false). This is an ansible level variable for flipping the install process to FIPS package ordering.
2. fips_mode = disabled|permissive|enabled (default=disabled). This is a Redpanda-level configuration for configuring the broker.

If enable_fips=true and fips_mode=enabled, we also proactively check the state of the OS deployment's FIPS support. If the OS appears to be incorrectly configured for FIPS, we have an assert that bails out. This assert can be bypassed by setting fips_mode=permissive. 