### PR TITLE
Configure sysctl fs.file-max

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: redpanda
 name: cluster
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.8.0
+version: 0.9.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/sysctl_setup/defaults/main.yml
+++ b/roles/sysctl_setup/defaults/main.yml
@@ -6,3 +6,10 @@
 # Adjust upwards as necessary. An upper limit has not been established. Increasing
 # this excessively can increase kernel memory usage. 
 max_user_instances: 8192
+
+
+# fs.file-max sets the max system-wide open file handles. This is necessary for
+# redpanda which can have a large number of active files and tcp connections 
+# open on a broker to service client requests. If set too low, redpanda will
+# fail with "too many open files" errors.
+max_open_filehandles: 1048576

--- a/roles/sysctl_setup/tasks/main.yml
+++ b/roles/sysctl_setup/tasks/main.yml
@@ -6,3 +6,14 @@
     state: present
     reload: true
   become: true
+
+# configure max open file handles since some distros may no longer be 
+# setting this high by default.
+- name: configure fs.file-max for redpanda
+  ansible.posix.sysctl:
+    name: fs.file-max
+    value: "{{ max_open_filehandles }}"
+    sysctl_set: true
+    state: present
+    reload: true
+  become: true


### PR DESCRIPTION
We should probably be explicitly setting sysctl fs.file-max with Ansible rather than depending on the OS distribution to have a sane default. 