### PR TITLE
fix: allow erasing curl

### DIFF
--- a/roles/system_setup/tasks/install-node-deps-rpm.yml
+++ b/roles/system_setup/tasks/install-node-deps-rpm.yml
@@ -42,5 +42,6 @@
   become: true
   ansible.builtin.package:
     name: "{{ rpm_prerequisite_packages }}"
+    allowerasing: true
     state: present
     update_cache: true


### PR DESCRIPTION
When installing on Amazon Linux 2023, the curl and curl-minimal packages conflict. This allows erasing of installed packages to replace curl-minimal with curl.