### PR TITLE
Avoid substring match when deriving node_id from rpk

### DIFF
--- a/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -138,7 +138,7 @@
 #
 - name: Establish node id
   ansible.builtin.shell:
-    cmd: rpk cluster status {{ redpanda_rpk_opts }} | sed 's/*//g' | grep {{ hostvars[inventory_hostname].private_ip }} | awk '{ print $1;}'
+    cmd: >- rpk cluster status {{ redpanda_rpk_opts }} | awk '$2=={{ hostvars[inventory_hostname].private_ip | quote }} { gsub(/\*/,"",$1); print $1 }'
   register: node_id_out
   changed_when: false
 


### PR DESCRIPTION
closes #129 