### PR TITLE
Migrate package repository URLs, signing keys and download paths to the new Artifact Registry

### DIFF
--- a/roles/binary_bundler/defaults/main.yml
+++ b/roles/binary_bundler/defaults/main.yml
@@ -1,5 +1,5 @@
 # defaults
-redpanda_base_url: "https://dl.redpanda.com"
+redpanda_base_url: "https://linux.pkg.redpanda.com"
 download_directory: "/tmp"
 
 # required config from user:
@@ -14,8 +14,8 @@ is_post_split: "{{ redpanda_version >= '24.2' or redpanda_version == 'latest' }}
 
 # the rpms
 rpm_package_suffix: "{{ '' if redpanda_version=='latest' else ('=' if ansible_os_family == 'Debian' else '-') + redpanda_version }}.{{ basearch }}"
-rpm_base_url: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ (os_distribution == 'RedHat') | ternary('el', os_distribution | lower) }}/{{ os_distribution_major_version }}"
-rpm_unstable_base_url: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ (os_distribution == 'RedHat') | ternary('el', os_distribution | lower) }}/{{ os_distribution_major_version }}"
+rpm_base_url: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rpm_unstable_base_url: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
 redpanda_package_name: "redpanda{{ rpm_package_suffix }}.rpm"
 redpanda_rpk_package_name: "redpanda-rpk{{ rpm_package_suffix }}.rpm"
 redpanda_tuner_package_name: "redpanda-tuner{{ rpm_package_suffix }}.rpm"
@@ -97,8 +97,8 @@ rpm_noarch_unstable_download_urls: "{{ post_split_noarch_rpms_unstable if is_pos
 rpm_source_unstable_download_urls: "{{ post_split_source_rpms_unstable if is_post_split else pre_split_source_rpms_unstable }}"
 
 # the debs
-deb_download_url: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
-deb_unstable_download_url: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+deb_download_url: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+deb_unstable_download_url: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 pre_split_deb_download_urls:
   redpanda: "{{ deb_download_url }}"
@@ -107,14 +107,14 @@ pre_split_deb_unstable_download_urls:
   redpanda: "{{ deb_unstable_download_url }}"
 
 post_split_deb_download_urls:
-  redpanda-rpk: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-rpk_{{ redpanda_version}}/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda-tuner: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-tuner_{{ redpanda_version}}/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-rpk: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-rpk/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-tuner: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-tuner/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 post_split_deb_unstable_download_urls:
-  redpanda-rpk: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-rpk_{{ redpanda_version}}/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda-tuner: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-tuner_{{ redpanda_version}}/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-rpk: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-rpk/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-tuner: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-tuner/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 deb_download_urls: "{{ post_split_deb_download_urls if is_post_split else pre_split_deb_download_urls }}"
 deb_unstable_download_urls: "{{ post_split_deb_unstable_download_urls if is_post_split else post_split_deb_unstable_download_urls }}"

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -14,7 +14,7 @@ redpanda_user: redpanda
 redpanda_group: redpanda
 
 redpanda_use_staging_repo: false
-redpanda_base_url: "https://dl.redpanda.com"
+redpanda_base_url: "https://linux.pkg.redpanda.com"
 
 redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
 
@@ -51,14 +51,14 @@ airgap_copy_src: "/tmp"
 airgap_copy_dest: "/tmp"
 
 # the rpms
-rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"
-rp_key_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/gpg.39C20393EC2E8747.key"
-rp_standard_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/$basearch"
-rp_standard_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/$basearch"
-rp_noarch_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/noarch"
-rp_noarch_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/noarch"
-rp_source_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/SRPMS"
-rp_source_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/SRPMS"
+rp_key_rpm: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+rp_key_rpm_unstable: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+rp_standard_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_standard_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
+rp_noarch_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_noarch_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
+rp_source_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_source_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
 rp_conf_loc_rpm: "/etc/yum.repos.d/redpanda-redpanda.repo"
 rp_rpm_distro_map:
   Fedora: fedora
@@ -67,16 +67,16 @@ rp_rpm_distro_map:
 
 
 # the debs
-rp_key_deb: "{{ redpanda_base_url }}/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
-rp_key_deb_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/gpg.39C20393EC2E8747.key"
+rp_key_deb: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
+rp_key_deb_unstable: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
 rp_conf_loc_deb: "/etc/apt/sources.list.d/redpanda.list"
 rp_conf_loc_deb_unstable: "etc/apt/sources.list.d/redpanda-redpanda-unstable.list"
 rp_key_path_deb: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg"
 rp_key_path_deb_unstable: "/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg"
-rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_deb_unstable: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_src_deb_unstable: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"
+rp_repo_signing_deb_unstable: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-unstable-apt main"
+rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"
+rp_repo_signing_src_deb_unstable: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-unstable-apt main"
 
 redpanda_broker_no_log: true
 

--- a/roles/redpanda_broker/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-deb-repository.yml
@@ -6,6 +6,12 @@
     rp_repo_signing_deb_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_repo_signing_deb_unstable, rp_repo_signing_deb) }}"
     rp_repo_signing_src_deb_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_repo_signing_src_deb_unstable, rp_repo_signing_src_deb) }}"
 
+- name: Debug Redpanda DEB repository URLs
+  ansible.builtin.debug:
+    msg:
+      - "GPG key URL: {{ rp_key_deb_actual }}"
+      - "Repo signing line: {{ rp_repo_signing_deb_actual }}"
+
 - name: Download and import Redpanda GPG Key with proxy
   become: true
   ansible.builtin.shell: |

--- a/roles/redpanda_broker/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-rpm-repository.yml
@@ -7,13 +7,20 @@
     rp_source_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_source_rpm_unstable, rp_source_rpm) }}"
     repo_name_prefix: "{{ is_using_unstable | bool | default(false) | ternary('redpanda-redpanda-unstable', 'redpanda-redpanda') }}"
 
+- name: Debug Redpanda RPM repository URLs
+  ansible.builtin.debug:
+    msg:
+      - "GPG key URL: {{ rp_key_rpm_actual }}"
+      - "Standard RPM baseurl: {{ rp_standard_rpm_actual }}"
+      - "Noarch RPM baseurl: {{ rp_noarch_rpm_actual }}"
+
 - name: Add redpanda-redpanda RPM repository
   ansible.builtin.yum_repository:
     name: "{{ repo_name_prefix }}"
     description: "{{ repo_name_prefix }}"
     baseurl: "{{ rp_standard_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -28,7 +35,7 @@
     description: "{{ repo_name_prefix }}-noarch"
     baseurl: "{{ rp_noarch_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -43,7 +50,7 @@
     description: "{{ repo_name_prefix }}-source"
     baseurl: "{{ rp_source_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'

--- a/roles/redpanda_console/defaults/main.yml
+++ b/roles/redpanda_console/defaults/main.yml
@@ -15,7 +15,7 @@ redpanda_user: redpanda
 redpanda_console_group: redpanda-console
 redpanda_console_user: redpanda-console
 
-redpanda_base_url: "https://dl.redpanda.com"
+redpanda_base_url: "https://linux.pkg.redpanda.com"
 
 redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
 
@@ -34,10 +34,10 @@ console_key_file: "{{ console_certs_dir }}/node.key"
 console_cert_file: "{{ console_certs_dir }}/node.crt"
 
 # the rpms
-rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"
-rp_standard_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/$basearch"
-rp_noarch_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/noarch"
-rp_source_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/SRPMS"
+rp_key_rpm: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+rp_standard_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_noarch_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_source_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
 rp_rpm_distro_map:
   Fedora: fedora
   Amazon: amzn
@@ -45,8 +45,8 @@ rp_rpm_distro_map:
 
 
 # the debs
-rp_key_deb: "{{ redpanda_base_url }}/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
-rp_key_deb_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/gpg.39C20393EC2E8747.key"
+rp_key_deb: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
+rp_key_deb_unstable: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
 rp_key_path_deb: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg"
-rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"
+rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"

--- a/roles/redpanda_console/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_console/tasks/configure-rpm-repository.yml
@@ -13,7 +13,7 @@
     description: "{{ repo_name_prefix }}"
     baseurl: "{{ rp_standard_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -28,7 +28,7 @@
     description: "{{ repo_name_prefix }}-noarch"
     baseurl: "{{ rp_noarch_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -43,7 +43,7 @@
     description: "{{ repo_name_prefix }}-source"
     baseurl: "{{ rp_source_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'


### PR DESCRIPTION
Update RPM and DEB repository URLs, signing key URLs, and APT/YUM configuration across the redpanda_broker, redpanda_console, and binary_bundler roles to pull Redpanda packages from the new Artifact Registry. This request should be merged during the transition to the new artifact registry.

RPM tasks set `repo_gpgcheck=false` because the Artifact Registry does not sign repository metadata. Without this, DNF silently skips the repo and reports "No package available" with no error. Setting `repo_gpgcheck=false` is correct: transport is HTTPS and individual package integrity is still enforced by `gpgcheck=true`.

**Not changed:**
- `cloudsmith_*` nightly variables in `roles/redpanda_broker/defaults/main.yml` — nightly builds have no Artifact Registry equivalent and intentionally remain on Cloudsmith.