### PR TITLE
fix: honor pinned redpanda_version in RPM split-package install

### DIFF
--- a/roles/redpanda_broker/tasks/install-rp-rpm.yml
+++ b/roles/redpanda_broker/tasks/install-rp-rpm.yml
@@ -34,6 +34,11 @@
   when: not needs_split_packages
 
 
+# Loop over the versioned package names so a pinned redpanda_version is
+# honored; with redpanda_version=latest the suffix is empty and this list is
+# identical to the unversioned one. (Previously this looped over the
+# unversioned list, so dnf always resolved the newest version in the repo and
+# silently ignored redpanda_version for releases >= 24.2.)
 - name: Install redpanda (post 24.2 or development)
   dnf:
     name: "{{item}}"
@@ -45,7 +50,7 @@
     http_proxy: "{{ https_proxy_value | default('') }}"
   register: package_result
   when: needs_split_packages
-  loop: "{{ redpanda_package_list }}"
+  loop: "{{ redpanda_package_list_versioned }}"
 
 # Stop redpanda if it auto-started after package installation
 # This prevents it from initializing before we can configure SASL


### PR DESCRIPTION
## Problem

On RPM-based systems (RHEL/Rocky/Fedora), `redpanda_version` is silently ignored for any release >= 24.2.

`roles/redpanda_broker/tasks/install-rp-rpm.yml` builds `redpanda_package_list_versioned` (e.g. `redpanda-25.3.15-1`, `redpanda-rpk-25.3.15-1`, `redpanda-tuner-25.3.15-1`) — but the *Install redpanda (post 24.2 or development)* task loops over the **unversioned** `redpanda_package_list`, so the versioned list is dead code and dnf resolves whatever is newest in the repo.

Consequences:
- Fresh installs with a pinned version get the latest release instead.
- Upgrades with `redpanda_install_status: latest` jump straight to the newest release, skipping the pinned intermediate version — which breaks the supported one-minor-at-a-time upgrade path.

### Field report

Reported in Redpanda Community Slack (RHEL, collection 0.11): a staged rolling upgrade `25.2.9 → 25.3.15 → 26.1.9` pinned `redpanda_version: 25.3.15-1`, but the role skipped 25.3.15 and went straight to 26.1.9, breaking the cluster.

## Fix

Loop over `redpanda_package_list_versioned` instead. This matches the Debian path (`install-rp-deb.yml`), which already appends the version suffix to each split-package name.

No behavior change for `redpanda_version: latest`: the suffix is empty, so the versioned list is identical to the unversioned one (this also keeps the FIPS package-list logic untouched).

## Testing notes

- `redpanda_version: latest` → package specs unchanged (`redpanda`, `redpanda-rpk`, `redpanda-tuner`).
- `redpanda_version: 25.3.15-1` → dnf receives `redpanda-25.3.15-1` etc. (valid `name-version-release` spec), installing/upgrading to exactly that build.
- Downgrade protection unchanged: `allow_downgrade` still only with `development_build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)