### PR TITLE
fix: tiered_storage.j2 emits invalid JSON; harden template tests to catch it

### DIFF
--- a/roles/redpanda_broker/templates/configs/tiered_storage.j2
+++ b/roles/redpanda_broker/templates/configs/tiered_storage.j2
@@ -5,11 +5,11 @@
 "cloud_storage_enable_remote_write": "{{ cloud_storage_enable_remote_write }}",
 "cloud_storage_region": "{{ cloud_storage_region if cloud_storage_region is defined }}",
 "cloud_storage_credentials_source": "{{ cloud_storage_credentials_source }}",
-# cloud_storage_enabled is true if the bucket name is set and the cloud_storage_credentials_source isn't set to "config_file".
-# If config_file is required, you'll need to specify the cloud_storage_access_key, cloud_storage_secret_key and also cloud_storage_enabled=true
-# using the redpanda variable which gets merged into these templates.
+{# cloud_storage_enabled is true if the bucket name is set and the cloud_storage_credentials_source isn't set to "config_file".
+   If config_file is required, you'll need to specify the cloud_storage_access_key, cloud_storage_secret_key and also cloud_storage_enabled=true
+   using the redpanda variable which gets merged into these templates. #}
 "cloud_storage_enabled": "{{ true if tiered_storage_bucket_name is defined and tiered_storage_bucket_name|d('')|length > 0 and cloud_storage_credentials_source != "config_file" else false }}"{% if cloud_storage_credentials_source == 'gcp_instance_metadata' %},
-"cloud_storage_api_endpoint": "storage.googleapis.com",
+"cloud_storage_api_endpoint": "storage.googleapis.com"
 {% endif %}
 }
 }

--- a/roles/redpanda_broker/tests/defaults_test.py
+++ b/roles/redpanda_broker/tests/defaults_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import json
 import yaml
 from jinja2 import Environment, FileSystemLoader, Undefined
 
@@ -95,7 +96,7 @@ class TestRedpandaTemplate(unittest.TestCase):
         )
 
         # Convert the rendered template to a dictionary for easier comparison
-        rendered_dict = yaml.safe_load(rendered_template)
+        rendered_dict = json.loads(rendered_template)
 
         # When redpanda_kafka_listeners is defined (as in defaults), it uses those listeners
         # The listener should have a name from the defined listeners
@@ -132,7 +133,7 @@ class TestRedpandaTemplate(unittest.TestCase):
             **defaults_no_listeners
         )
 
-        rendered_dict = yaml.safe_load(rendered_template)
+        rendered_dict = json.loads(rendered_template)
 
         # Verify kafka_api has name even without SASL
         kafka_api = rendered_dict['node']['redpanda']['kafka_api']
@@ -179,7 +180,7 @@ class TestRedpandaTemplate(unittest.TestCase):
             **defaults_with_kafka_listeners
         )
 
-        rendered_dict = yaml.safe_load(rendered_template)
+        rendered_dict = json.loads(rendered_template)
 
         kafka_api = rendered_dict['node']['redpanda']['kafka_api']
         advertised_kafka_api = rendered_dict['node']['redpanda']['advertised_kafka_api']
@@ -226,7 +227,7 @@ class TestRedpandaTemplate(unittest.TestCase):
             **defaults_sasl
         )
 
-        rendered_dict = yaml.safe_load(rendered_template)
+        rendered_dict = json.loads(rendered_template)
 
         # Verify kafka_api has authentication_method: sasl
         kafka_api = rendered_dict['node']['redpanda']['kafka_api']

--- a/roles/redpanda_broker/tests/tiered-storage_test.py
+++ b/roles/redpanda_broker/tests/tiered-storage_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import json
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
@@ -77,8 +78,10 @@ class TestRedpandaTemplate(unittest.TestCase):
             }
         }
 
-        # Convert the rendered template to a dictionary for easier comparison
-        rendered_dict = yaml.safe_load(rendered_template)
+        # Parse the rendered template as JSON — this matches how the role actually
+        # consumes it at runtime (start-redpanda.yml uses the from_json filter). YAML
+        # would silently tolerate JSON-invalid content (e.g. `#` comment lines).
+        rendered_dict = json.loads(rendered_template)
 
         # Assert that the expected values are in the rendered template
         self.assertEqual(rendered_dict, expected_rendered_values)

--- a/roles/redpanda_broker/tests/tls_test.py
+++ b/roles/redpanda_broker/tests/tls_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import json
 import yaml
 from jinja2 import Environment, FileSystemLoader, Undefined
 
@@ -144,7 +145,7 @@ class TestRedpandaTemplate(unittest.TestCase):
             }
         }
 
-        rendered_dict = yaml.safe_load(rendered_template)
+        rendered_dict = json.loads(rendered_template)
         self.assertEqual(rendered_dict, expected_rendered_values)
 
         print(rendered_template)
@@ -173,7 +174,7 @@ class TestRedpandaTemplate(unittest.TestCase):
 
         rendered_template = self.env.from_string(first_pass).render(**defaults_no_listeners)
 
-        rendered_dict = yaml.safe_load(rendered_template)
+        rendered_dict = json.loads(rendered_template)
 
         # Verify kafka_api_tls is an array with exactly one entry
         kafka_api_tls = rendered_dict['node']['redpanda']['kafka_api_tls']

--- a/roles/redpanda_broker/tests/tpl_test.py
+++ b/roles/redpanda_broker/tests/tpl_test.py
@@ -95,6 +95,28 @@ class TestBrokerTemplates:
         assert config['node']['redpanda']['rpc_server_tls']['enabled'] == True
         assert 'organization' in config['node']
 
+    def test_defaults_tiered_storage_merge(self):
+        # Exercises tiered_storage.j2 through the real from_json config-merge path
+        # (start-redpanda.yml), so JSON-invalid template output fails the play here
+        # rather than silently passing a yaml-only unit test.
+        templates = [
+            {"template": "/app/templates/configs/defaults.j2"},
+            {"template": "/app/templates/configs/tiered_storage.j2"}
+        ]
+        status, config = run(templates, {
+            'tiered_storage_bucket_name': 'my-bucket',
+            'cloud_storage_enable_remote_read': 'true',
+            'cloud_storage_enable_remote_write': 'true',
+            'cloud_storage_region': 'us-west-2',
+            'cloud_storage_credentials_source': 'gcp_instance_metadata',
+        })
+        assert status == 'successful'
+        assert config['cluster']['cloud_storage_bucket'] == 'my-bucket'
+        assert config['cluster']['cloud_storage_credentials_source'] == 'gcp_instance_metadata'
+        # gcp_instance_metadata branch must add the GCS endpoint (and stay valid JSON)
+        assert config['cluster']['cloud_storage_api_endpoint'] == 'storage.googleapis.com'
+        assert 'organization' in config['node']
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem
`tiered_storage.j2` rendered **invalid JSON**, which the `redpanda_broker` role rejects at runtime via the `from_json` filter (`start-redpanda.yml`), breaking tiered-storage config generation:

```
from_json failed: Expecting property name enclosed in double quotes: line 8 column 1
```

Two distinct bugs in the template:
1. **Literal `#` comment lines** — Jinja only strips `{# #}`, so `#` lines rendered straight into the JSON.
2. **Trailing comma** after `cloud_storage_api_endpoint` in the `gcp_instance_metadata` branch.

## Why the tests didn't catch it
The JSON-config unit tests validated rendered output with **`yaml.safe_load`** — but YAML treats `#` as a comment and tolerates trailing commas, so they passed while the runtime `from_json` fails. And the functional test that *does* use the real `from_json` path (`tpl_test.py`) only covered `defaults.j2` and `tls.j2` — never `tiered_storage.j2`. So this template was tested only by a parser that couldn't see the bug.

## Fix
- **Template:** use `{# #}` comments and drop the trailing comma so it emits valid JSON on all branches.
- **Unit tests** (`tiered-storage`, `tls`, `defaults`): parse rendered configs with `json.loads` to match the runtime `from_json`.
- **Functional coverage:** add `tiered_storage.j2` to `tpl_test.py`'s `from_json` merge test, so it's protected at both layers like the other JSON configs.

Verified in the role's docker test harness — **10 passed**. The tiered test now fails if the template ever emits invalid JSON again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
