### PR TITLE
AR migration: reliable apt signing-key handling on upgrade + fresh install (includes #145)

### DIFF
--- a/roles/binary_bundler/defaults/main.yml
+++ b/roles/binary_bundler/defaults/main.yml
@@ -1,5 +1,5 @@
 # defaults
-redpanda_base_url: "https://dl.redpanda.com"
+redpanda_base_url: "https://linux.pkg.redpanda.com"
 download_directory: "/tmp"
 
 # required config from user:
@@ -14,8 +14,8 @@ is_post_split: "{{ redpanda_version >= '24.2' or redpanda_version == 'latest' }}
 
 # the rpms
 rpm_package_suffix: "{{ '' if redpanda_version=='latest' else ('=' if ansible_os_family == 'Debian' else '-') + redpanda_version }}.{{ basearch }}"
-rpm_base_url: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ (os_distribution == 'RedHat') | ternary('el', os_distribution | lower) }}/{{ os_distribution_major_version }}"
-rpm_unstable_base_url: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ (os_distribution == 'RedHat') | ternary('el', os_distribution | lower) }}/{{ os_distribution_major_version }}"
+rpm_base_url: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rpm_unstable_base_url: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
 redpanda_package_name: "redpanda{{ rpm_package_suffix }}.rpm"
 redpanda_rpk_package_name: "redpanda-rpk{{ rpm_package_suffix }}.rpm"
 redpanda_tuner_package_name: "redpanda-tuner{{ rpm_package_suffix }}.rpm"
@@ -97,8 +97,8 @@ rpm_noarch_unstable_download_urls: "{{ post_split_noarch_rpms_unstable if is_pos
 rpm_source_unstable_download_urls: "{{ post_split_source_rpms_unstable if is_post_split else pre_split_source_rpms_unstable }}"
 
 # the debs
-deb_download_url: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
-deb_unstable_download_url: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+deb_download_url: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+deb_unstable_download_url: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 pre_split_deb_download_urls:
   redpanda: "{{ deb_download_url }}"
@@ -107,14 +107,14 @@ pre_split_deb_unstable_download_urls:
   redpanda: "{{ deb_unstable_download_url }}"
 
 post_split_deb_download_urls:
-  redpanda-rpk: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-rpk_{{ redpanda_version}}/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda-tuner: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-tuner_{{ redpanda_version}}/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda: "https://dl.redpanda.com/public/redpanda/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-rpk: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-rpk/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-tuner: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-tuner/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 post_split_deb_unstable_download_urls:
-  redpanda-rpk: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-rpk_{{ redpanda_version}}/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda-tuner: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda-tuner_{{ redpanda_version}}/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda: "https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ os_distribution }}/pool/any-version/main/r/re/redpanda_{{ redpanda_version}}/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-rpk: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-rpk/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-tuner: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-tuner/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 deb_download_urls: "{{ post_split_deb_download_urls if is_post_split else pre_split_deb_download_urls }}"
 deb_unstable_download_urls: "{{ post_split_deb_unstable_download_urls if is_post_split else post_split_deb_unstable_download_urls }}"

--- a/roles/binary_bundler/defaults/main.yml
+++ b/roles/binary_bundler/defaults/main.yml
@@ -98,7 +98,9 @@ rpm_source_unstable_download_urls: "{{ post_split_source_rpms_unstable if is_pos
 
 # the debs
 deb_download_url: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
-deb_unstable_download_url: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+# Unstable packages live in the Artifact Registry unstable pool component
+# (redpanda-unstable-apt), distinct from the stable pool above.
+deb_unstable_download_url: "{{ redpanda_base_url }}/apt/pool/redpanda-unstable-apt/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 pre_split_deb_download_urls:
   redpanda: "{{ deb_download_url }}"
@@ -112,9 +114,9 @@ post_split_deb_download_urls:
   redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 post_split_deb_unstable_download_urls:
-  redpanda-rpk: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-rpk/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda-tuner: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda-tuner/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
-  redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-rpk: "{{ redpanda_base_url }}/apt/pool/redpanda-unstable-apt/redpanda-rpk_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda-tuner: "{{ redpanda_base_url }}/apt/pool/redpanda-unstable-apt/redpanda-tuner_{{ redpanda_version }}_{{ basearch }}.deb"
+  redpanda: "{{ redpanda_base_url }}/apt/pool/redpanda-unstable-apt/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 deb_download_urls: "{{ post_split_deb_download_urls if is_post_split else pre_split_deb_download_urls }}"
 deb_unstable_download_urls: "{{ post_split_deb_unstable_download_urls if is_post_split else pre_split_deb_unstable_download_urls }}"

--- a/roles/binary_bundler/defaults/main.yml
+++ b/roles/binary_bundler/defaults/main.yml
@@ -117,4 +117,4 @@ post_split_deb_unstable_download_urls:
   redpanda: "{{ redpanda_base_url }}/apt/pool/main/r/redpanda/redpanda_{{ redpanda_version }}_{{ basearch }}.deb"
 
 deb_download_urls: "{{ post_split_deb_download_urls if is_post_split else pre_split_deb_download_urls }}"
-deb_unstable_download_urls: "{{ post_split_deb_unstable_download_urls if is_post_split else post_split_deb_unstable_download_urls }}"
+deb_unstable_download_urls: "{{ post_split_deb_unstable_download_urls if is_post_split else pre_split_deb_unstable_download_urls }}"

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -14,7 +14,7 @@ redpanda_user: redpanda
 redpanda_group: redpanda
 
 redpanda_use_staging_repo: false
-redpanda_base_url: "https://dl.redpanda.com"
+redpanda_base_url: "https://linux.pkg.redpanda.com"
 
 redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
 
@@ -54,14 +54,14 @@ airgap_copy_src: "/tmp"
 airgap_copy_dest: "/tmp"
 
 # the rpms
-rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"
-rp_key_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/gpg.39C20393EC2E8747.key"
-rp_standard_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/$basearch"
-rp_standard_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/$basearch"
-rp_noarch_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/noarch"
-rp_noarch_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/noarch"
-rp_source_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/SRPMS"
-rp_source_rpm_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/SRPMS"
+rp_key_rpm: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+rp_key_rpm_unstable: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+rp_standard_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_standard_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
+rp_noarch_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_noarch_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
+rp_source_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_source_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
 rp_conf_loc_rpm: "/etc/yum.repos.d/redpanda-redpanda.repo"
 rp_rpm_distro_map:
   Fedora: fedora
@@ -70,16 +70,16 @@ rp_rpm_distro_map:
 
 
 # the debs
-rp_key_deb: "{{ redpanda_base_url }}/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
-rp_key_deb_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/gpg.39C20393EC2E8747.key"
+rp_key_deb: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
+rp_key_deb_unstable: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
 rp_conf_loc_deb: "/etc/apt/sources.list.d/redpanda.list"
 rp_conf_loc_deb_unstable: "etc/apt/sources.list.d/redpanda-redpanda-unstable.list"
 rp_key_path_deb: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg"
 rp_key_path_deb_unstable: "/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg"
-rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_deb_unstable: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_src_deb_unstable: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"
+rp_repo_signing_deb_unstable: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-unstable-apt main"
+rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"
+rp_repo_signing_src_deb_unstable: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-unstable-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-unstable-apt main"
 
 redpanda_broker_no_log: true
 

--- a/roles/redpanda_broker/defaults/main.yml
+++ b/roles/redpanda_broker/defaults/main.yml
@@ -55,6 +55,12 @@ airgap_copy_dest: "/tmp"
 
 # the rpms
 rp_key_rpm: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+# Artifact Registry signs yum repo *metadata* (repodata/repomd.xml.asc) with
+# Google's own "Artifact Registry Repository Signer" key, published per repo at
+# repodata/repomd.xml.key. It is distinct from the Redpanda package-signing key
+# above; both are required for repo_gpgcheck=1 + gpgcheck=1.
+rp_key_rpm_metadata: "{{ redpanda_base_url }}/yum/redpanda-yum/repodata/repomd.xml.key"
+rp_key_rpm_metadata_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum/repodata/repomd.xml.key"
 rp_key_rpm_unstable: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
 rp_standard_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
 rp_standard_rpm_unstable: "{{ redpanda_base_url }}/yum/redpanda-unstable-yum"
@@ -90,7 +96,6 @@ cloudsmith_config_url_deb: "https://dl.redpanda.com/{{ cloudsmith_token }}/redpa
 cloudsmith_config_url_rpm: "https://dl.redpanda.com/{{ cloudsmith_token }}/redpanda-nightly/config.rpm.txt"
 keyring_location: '/usr/share/keyrings/redpanda-redpanda-nightly-archive-keyring.gpg'
 development_build: false
-
 
 
 # enable fips. requires an enterprise license.

--- a/roles/redpanda_broker/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-deb-repository.yml
@@ -6,6 +6,12 @@
     rp_repo_signing_deb_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_repo_signing_deb_unstable, rp_repo_signing_deb) }}"
     rp_repo_signing_src_deb_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_repo_signing_src_deb_unstable, rp_repo_signing_src_deb) }}"
 
+- name: Debug Redpanda DEB repository URLs
+  ansible.builtin.debug:
+    msg:
+      - "GPG key URL: {{ rp_key_deb_actual }}"
+      - "Repo signing line: {{ rp_repo_signing_deb_actual }}"
+
 - name: Download and import Redpanda GPG Key with proxy
   become: true
   ansible.builtin.shell: |

--- a/roles/redpanda_broker/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-deb-repository.yml
@@ -12,21 +12,55 @@
       - "GPG key URL: {{ rp_key_deb_actual }}"
       - "Repo signing line: {{ rp_repo_signing_deb_actual }}"
 
-- name: Download and import Redpanda GPG Key with proxy
-  become: true
-  ansible.builtin.shell: |
-    curl -x "{{ https_proxy_value }}" -1sLf "{{ rp_key_deb_actual }}" | gpg --dearmor > "{{ rp_key_path_deb_actual }}"
-  args:
-    creates: "{{ rp_key_path_deb_actual }}"
-  when: https_proxy_value is defined and https_proxy_value | length > 0
+# Import the Redpanda signing key only when the keyring is missing the key the
+# repository is actually signed with. This stays idempotent in steady state
+# (a no-op once the key is present) while still performing the one-time cutover
+# when migrating an existing host onto a new key (e.g. the dl.redpanda.com ->
+# Artifact Registry migration) or on any future key rotation. The required
+# fingerprint is derived from whatever key the configured URL currently serves,
+# so this never needs revisiting when the signing key changes.
+- name: Fetch the current Redpanda DEB signing key
+  ansible.builtin.get_url:
+    url: "{{ rp_key_deb_actual }}"
+    dest: /tmp/redpanda-deb-signing.key
+    mode: '0644'
+  environment:
+    https_proxy: "{{ https_proxy_value | default('') }}"
+    http_proxy: "{{ https_proxy_value | default('') }}"
+  changed_when: false
 
-- name: Download and import Redpanda GPG Key without proxy
-  become: true
+- name: Determine the signing key fingerprint we require
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    gpg --show-keys --with-colons /tmp/redpanda-deb-signing.key | awk -F: '/^fpr:/{print $10; exit}'
   args:
-    creates: "{{ rp_key_path_deb_actual }}"
-  ansible.builtin.shell: |
-    curl -1sLf "{{ rp_key_deb_actual }}" | gpg --dearmor > "{{ rp_key_path_deb_actual }}"
-  when: https_proxy_value is not defined or https_proxy_value | length == 0
+    executable: /bin/bash
+  register: rp_want_deb_key_fpr
+  changed_when: false
+
+- name: Read the fingerprints already present in the Redpanda keyring
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    gpg --no-default-keyring --keyring "{{ rp_key_path_deb_actual }}" --list-keys --with-colons 2>/dev/null
+    | awk -F: '/^fpr:/{print $10}'
+  args:
+    executable: /bin/bash
+  register: rp_have_deb_key_fprs
+  changed_when: false
+  failed_when: false
+
+- name: Import/refresh the Redpanda signing key when it is missing (migration / rotation)
+  become: true
+  ansible.builtin.command: gpg --dearmor --yes -o "{{ rp_key_path_deb_actual }}" /tmp/redpanda-deb-signing.key
+  when: rp_want_deb_key_fpr.stdout not in (rp_have_deb_key_fprs.stdout_lines | default([]))
+
+# `gpg --dearmor -o` creates a fresh keyring 0600 root; apt verifies signed-by keyrings as the
+# _apt user, which then can't read it (NO_PUBKEY). Force it world-readable like a public key file.
+- name: Ensure the Redpanda keyring is world-readable for apt verification
+  become: true
+  ansible.builtin.file:
+    path: "{{ rp_key_path_deb_actual }}"
+    mode: '0644'
 
 - name: Add Redpanda DEB repository
   ansible.builtin.copy:

--- a/roles/redpanda_broker/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-deb-repository.yml
@@ -12,13 +12,12 @@
       - "GPG key URL: {{ rp_key_deb_actual }}"
       - "Repo signing line: {{ rp_repo_signing_deb_actual }}"
 
-# Import the Redpanda signing key only when the keyring is missing the key the
-# repository is actually signed with. This stays idempotent in steady state
-# (a no-op once the key is present) while still performing the one-time cutover
-# when migrating an existing host onto a new key (e.g. the dl.redpanda.com ->
-# Artifact Registry migration) or on any future key rotation. The required
-# fingerprint is derived from whatever key the configured URL currently serves,
-# so this never needs revisiting when the signing key changes.
+# Refresh the keyring whenever it differs from the key material the repository
+# URL currently serves. The comparison is over the WHOLE dearmored keyring, not
+# a single fingerprint: rotation bundles (old+new keys published together),
+# refreshed subkeys, and extended expirations all change the bytes and trigger
+# an atomic replace, while steady state stays a no-op. (A fingerprint-presence
+# gate would skip exactly the rotation events this mechanism exists for.)
 - name: Fetch the current Redpanda DEB signing key
   ansible.builtin.get_url:
     url: "{{ rp_key_deb_actual }}"
@@ -29,33 +28,30 @@
     http_proxy: "{{ https_proxy_value | default('') }}"
   changed_when: false
 
-- name: Determine the signing key fingerprint we require
-  ansible.builtin.shell: >-
-    set -o pipefail;
-    gpg --show-keys --with-colons /tmp/redpanda-deb-signing.key | awk -F: '/^fpr:/{print $10; exit}'
-  args:
-    executable: /bin/bash
-  register: rp_want_deb_key_fpr
+- name: Dearmor the fetched signing key for comparison
+  ansible.builtin.command: gpg --dearmor --yes -o /tmp/redpanda-deb-signing.dearmored /tmp/redpanda-deb-signing.key
   changed_when: false
 
-- name: Read the fingerprints already present in the Redpanda keyring
-  ansible.builtin.shell: >-
-    set -o pipefail;
-    gpg --no-default-keyring --keyring "{{ rp_key_path_deb_actual }}" --list-keys --with-colons 2>/dev/null
-    | awk -F: '/^fpr:/{print $10}'
-  args:
-    executable: /bin/bash
-  register: rp_have_deb_key_fprs
+- name: Check whether the installed keyring matches the served key material
+  ansible.builtin.command: cmp -s /tmp/redpanda-deb-signing.dearmored "{{ rp_key_path_deb_actual }}"
+  register: rp_deb_keyring_cmp
   changed_when: false
   failed_when: false
 
-- name: Import/refresh the Redpanda signing key when it is missing (migration / rotation)
+- name: Install/refresh the Redpanda keyring (migration / rotation)
   become: true
-  ansible.builtin.command: gpg --dearmor --yes -o "{{ rp_key_path_deb_actual }}" /tmp/redpanda-deb-signing.key
-  when: rp_want_deb_key_fpr.stdout not in (rp_have_deb_key_fprs.stdout_lines | default([]))
+  ansible.builtin.copy:
+    src: /tmp/redpanda-deb-signing.dearmored
+    dest: "{{ rp_key_path_deb_actual }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0644'
+  when: rp_deb_keyring_cmp.rc != 0
 
-# `gpg --dearmor -o` creates a fresh keyring 0600 root; apt verifies signed-by keyrings as the
-# _apt user, which then can't read it (NO_PUBKEY). Force it world-readable like a public key file.
+# apt verifies signed-by keyrings as the _apt user; a pre-existing root-only (0600)
+# keyring fails verification (NO_PUBKEY) even when its contents are correct, so
+# force it world-readable like a public key file regardless of who created it.
 - name: Ensure the Redpanda keyring is world-readable for apt verification
   become: true
   ansible.builtin.file:

--- a/roles/redpanda_broker/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-deb-repository.yml
@@ -8,6 +8,7 @@
 
 - name: Debug Redpanda DEB repository URLs
   ansible.builtin.debug:
+    verbosity: 2
     msg:
       - "GPG key URL: {{ rp_key_deb_actual }}"
       - "Repo signing line: {{ rp_repo_signing_deb_actual }}"

--- a/roles/redpanda_broker/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-rpm-repository.yml
@@ -7,13 +7,20 @@
     rp_source_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_source_rpm_unstable, rp_source_rpm) }}"
     repo_name_prefix: "{{ is_using_unstable | bool | default(false) | ternary('redpanda-redpanda-unstable', 'redpanda-redpanda') }}"
 
+- name: Debug Redpanda RPM repository URLs
+  ansible.builtin.debug:
+    msg:
+      - "GPG key URL: {{ rp_key_rpm_actual }}"
+      - "Standard RPM baseurl: {{ rp_standard_rpm_actual }}"
+      - "Noarch RPM baseurl: {{ rp_noarch_rpm_actual }}"
+
 - name: Add redpanda-redpanda RPM repository
   ansible.builtin.yum_repository:
     name: "{{ repo_name_prefix }}"
     description: "{{ repo_name_prefix }}"
     baseurl: "{{ rp_standard_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -28,7 +35,7 @@
     description: "{{ repo_name_prefix }}-noarch"
     baseurl: "{{ rp_noarch_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -43,7 +50,7 @@
     description: "{{ repo_name_prefix }}-source"
     baseurl: "{{ rp_source_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'

--- a/roles/redpanda_broker/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-rpm-repository.yml
@@ -25,6 +25,7 @@
 
 - name: Debug Redpanda RPM repository URLs
   ansible.builtin.debug:
+    verbosity: 2
     msg:
       - "GPG key URL: {{ rp_key_rpm_actual }}"
       - "Standard RPM baseurl: {{ rp_standard_rpm_actual }}"

--- a/roles/redpanda_broker/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-rpm-repository.yml
@@ -1,4 +1,19 @@
 ---
+# dnf5's repo-metadata verifier rejects the Artifact Registry repomd.xml signature
+# (a critical hashed Issuer subpacket gpg/dnf4 accept but dnf5 does not), so
+# repo_gpgcheck must be off on dnf5 hosts and stays on everywhere else. Package
+# payloads are still verified via gpgcheck=1 regardless. Google documents
+# repo_gpgcheck=0 as the AR client config:
+# https://cloud.google.com/artifact-registry/docs/os-packages/rpm/configure
+- name: Detect dnf5 (Artifact Registry repomd signatures fail its verifier)
+  ansible.builtin.stat:
+    path: /usr/bin/dnf5
+  register: rp_dnf5_bin
+
+- name: Set repo_gpgcheck (off on dnf5, on elsewhere)
+  ansible.builtin.set_fact:
+    rp_repo_gpgcheck: "{{ not rp_dnf5_bin.stat.exists }}"
+
 - name: Set Redpanda RPM and GPG Key details
   ansible.builtin.set_fact:
     rp_key_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_key_rpm_unstable, rp_key_rpm) }}"
@@ -25,7 +40,7 @@
     gpgkey:
       - "{{ rp_key_rpm_actual }}"
       - "{{ rp_key_rpm_metadata_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: "{{ rp_repo_gpgcheck }}"
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -44,7 +59,7 @@
     gpgkey:
       - "{{ rp_key_rpm_actual }}"
       - "{{ rp_key_rpm_metadata_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: "{{ rp_repo_gpgcheck }}"
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -63,7 +78,7 @@
     gpgkey:
       - "{{ rp_key_rpm_actual }}"
       - "{{ rp_key_rpm_metadata_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: "{{ rp_repo_gpgcheck }}"
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'

--- a/roles/redpanda_broker/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_broker/tasks/configure-rpm-repository.yml
@@ -2,6 +2,7 @@
 - name: Set Redpanda RPM and GPG Key details
   ansible.builtin.set_fact:
     rp_key_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_key_rpm_unstable, rp_key_rpm) }}"
+    rp_key_rpm_metadata_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_key_rpm_metadata_unstable, rp_key_rpm_metadata) }}"
     rp_standard_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_standard_rpm_unstable, rp_standard_rpm) }}"
     rp_noarch_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_noarch_rpm_unstable, rp_noarch_rpm) }}"
     rp_source_rpm_actual: "{{ is_using_unstable | bool | default(false) | ternary(rp_source_rpm_unstable, rp_source_rpm) }}"
@@ -19,8 +20,12 @@
     name: "{{ repo_name_prefix }}"
     description: "{{ repo_name_prefix }}"
     baseurl: "{{ rp_standard_rpm_actual }}"
-    gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: false
+    # package payloads are signed by Redpanda; repo metadata is signed by the
+    # Artifact Registry repository-signer key — both keys are needed
+    gpgkey:
+      - "{{ rp_key_rpm_actual }}"
+      - "{{ rp_key_rpm_metadata_actual }}"
+    repo_gpgcheck: true
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -34,8 +39,12 @@
     name: "{{ repo_name_prefix }}-noarch"
     description: "{{ repo_name_prefix }}-noarch"
     baseurl: "{{ rp_noarch_rpm_actual }}"
-    gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: false
+    # package payloads are signed by Redpanda; repo metadata is signed by the
+    # Artifact Registry repository-signer key — both keys are needed
+    gpgkey:
+      - "{{ rp_key_rpm_actual }}"
+      - "{{ rp_key_rpm_metadata_actual }}"
+    repo_gpgcheck: true
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -49,8 +58,12 @@
     name: "{{ repo_name_prefix }}-source"
     description: "{{ repo_name_prefix }}-source"
     baseurl: "{{ rp_source_rpm_actual }}"
-    gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: false
+    # package payloads are signed by Redpanda; repo metadata is signed by the
+    # Artifact Registry repository-signer key — both keys are needed
+    gpgkey:
+      - "{{ rp_key_rpm_actual }}"
+      - "{{ rp_key_rpm_metadata_actual }}"
+    repo_gpgcheck: true
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -64,11 +77,17 @@
     https_proxy: "{{ rpm_proxy | default('') }}"
   ansible.builtin.rpm_key:
     state: present
-    key: "{{ rp_key_rpm_actual }}"
+    key: "{{ item }}"
+  loop:
+    - "{{ rp_key_rpm_actual }}"
+    - "{{ rp_key_rpm_metadata_actual }}"
   when: https_proxy_value is defined and https_proxy_value | length > 0
 
 - name: Install GPG key
   ansible.builtin.rpm_key:
     state: present
-    key: "{{ rp_key_rpm_actual }}"
+    key: "{{ item }}"
+  loop:
+    - "{{ rp_key_rpm_actual }}"
+    - "{{ rp_key_rpm_metadata_actual }}"
   when: (https_proxy_value is not defined or https_proxy_value | length == 0)

--- a/roles/redpanda_console/defaults/main.yml
+++ b/roles/redpanda_console/defaults/main.yml
@@ -15,7 +15,7 @@ redpanda_user: redpanda
 redpanda_console_group: redpanda-console
 redpanda_console_user: redpanda-console
 
-redpanda_base_url: "https://dl.redpanda.com"
+redpanda_base_url: "https://linux.pkg.redpanda.com"
 
 redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
 
@@ -34,10 +34,10 @@ console_key_file: "{{ console_certs_dir }}/node.key"
 console_cert_file: "{{ console_certs_dir }}/node.crt"
 
 # the rpms
-rp_key_rpm: "{{ redpanda_base_url }}/public/redpanda/gpg.988A7B0A4918BC85.key"
-rp_standard_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/$basearch"
-rp_noarch_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/noarch"
-rp_source_rpm: "{{ redpanda_base_url }}/public/redpanda/rpm/{{ rp_rpm_distro_map[ansible_distribution] | default('el') }}/{{ ansible_distribution_major_version }}/SRPMS"
+rp_key_rpm: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+rp_standard_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_noarch_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
+rp_source_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
 rp_rpm_distro_map:
   Fedora: fedora
   Amazon: amzn
@@ -45,8 +45,8 @@ rp_rpm_distro_map:
 
 
 # the debs
-rp_key_deb: "{{ redpanda_base_url }}/sMIXnoa7DK12JW4A/redpanda/gpg.988A7B0A4918BC85.key"
-rp_key_deb_unstable: "{{ redpanda_base_url }}/E4xN1tVe3Xy60GTx/redpanda-unstable/gpg.39C20393EC2E8747.key"
+rp_key_deb: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
+rp_key_deb_unstable: "{{ redpanda_base_url }}/redpanda-deb-signing-public.gpg"
 rp_key_path_deb: "/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg"
-rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
-rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/public/redpanda/deb/{{ansible_distribution | lower}} {{ ansible_distribution_release | lower }} main"
+rp_repo_signing_deb: "deb [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"
+rp_repo_signing_src_deb: "deb-src [signed-by=/usr/share/keyrings/redpanda-redpanda-archive-keyring.gpg] {{ redpanda_base_url }}/apt redpanda-apt main"

--- a/roles/redpanda_console/defaults/main.yml
+++ b/roles/redpanda_console/defaults/main.yml
@@ -35,6 +35,11 @@ console_cert_file: "{{ console_certs_dir }}/node.crt"
 
 # the rpms
 rp_key_rpm: "{{ redpanda_base_url }}/redpanda-rpm-signing-public.key"
+# Artifact Registry signs yum repo *metadata* (repodata/repomd.xml.asc) with
+# Google's own "Artifact Registry Repository Signer" key, published per repo at
+# repodata/repomd.xml.key. It is distinct from the Redpanda package-signing key
+# above; both are required for repo_gpgcheck=1 + gpgcheck=1.
+rp_key_rpm_metadata: "{{ redpanda_base_url }}/yum/redpanda-yum/repodata/repomd.xml.key"
 rp_standard_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
 rp_noarch_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"
 rp_source_rpm: "{{ redpanda_base_url }}/yum/redpanda-yum"

--- a/roles/redpanda_console/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_console/tasks/configure-deb-repository.yml
@@ -6,21 +6,55 @@
     rp_repo_signing_deb_actual: "{{ rp_repo_signing_deb }}"
     rp_repo_signing_src_deb_actual: "{{ rp_repo_signing_src_deb }}"
 
-- name: Download and import Redpanda GPG Key with proxy
-  become: true
-  ansible.builtin.shell: |
-    curl -x "{{ https_proxy_value }}" -1sLf "{{ rp_key_deb_actual }}" | gpg --dearmor > "{{ rp_key_path_deb_actual }}"
-  args:
-    creates: "{{ rp_key_path_deb_actual }}"
-  when: https_proxy_value is defined and https_proxy_value | length > 0
+# Import the Redpanda signing key only when the keyring is missing the key the
+# repository is actually signed with. This stays idempotent in steady state
+# (a no-op once the key is present) while still performing the one-time cutover
+# when migrating an existing host onto a new key (e.g. the dl.redpanda.com ->
+# Artifact Registry migration) or on any future key rotation. The required
+# fingerprint is derived from whatever key the configured URL currently serves,
+# so this never needs revisiting when the signing key changes.
+- name: Fetch the current Redpanda DEB signing key
+  ansible.builtin.get_url:
+    url: "{{ rp_key_deb_actual }}"
+    dest: /tmp/redpanda-deb-signing.key
+    mode: '0644'
+  environment:
+    https_proxy: "{{ https_proxy_value | default('') }}"
+    http_proxy: "{{ https_proxy_value | default('') }}"
+  changed_when: false
 
-- name: Download and import Redpanda GPG Key without proxy
-  become: true
+- name: Determine the signing key fingerprint we require
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    gpg --show-keys --with-colons /tmp/redpanda-deb-signing.key | awk -F: '/^fpr:/{print $10; exit}'
   args:
-    creates: "{{ rp_key_path_deb_actual }}"
-  ansible.builtin.shell: |
-    curl -1sLf "{{ rp_key_deb_actual }}" | gpg --dearmor > "{{ rp_key_path_deb_actual }}"
-  when: https_proxy_value is not defined or https_proxy_value | length == 0
+    executable: /bin/bash
+  register: rp_want_deb_key_fpr
+  changed_when: false
+
+- name: Read the fingerprints already present in the Redpanda keyring
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    gpg --no-default-keyring --keyring "{{ rp_key_path_deb_actual }}" --list-keys --with-colons 2>/dev/null
+    | awk -F: '/^fpr:/{print $10}'
+  args:
+    executable: /bin/bash
+  register: rp_have_deb_key_fprs
+  changed_when: false
+  failed_when: false
+
+- name: Import/refresh the Redpanda signing key when it is missing (migration / rotation)
+  become: true
+  ansible.builtin.command: gpg --dearmor --yes -o "{{ rp_key_path_deb_actual }}" /tmp/redpanda-deb-signing.key
+  when: rp_want_deb_key_fpr.stdout not in (rp_have_deb_key_fprs.stdout_lines | default([]))
+
+# `gpg --dearmor -o` creates a fresh keyring 0600 root; apt verifies signed-by keyrings as the
+# _apt user, which then can't read it (NO_PUBKEY). Force it world-readable like a public key file.
+- name: Ensure the Redpanda keyring is world-readable for apt verification
+  become: true
+  ansible.builtin.file:
+    path: "{{ rp_key_path_deb_actual }}"
+    mode: '0644'
 
 - name: Add Redpanda DEB repository
   ansible.builtin.copy:

--- a/roles/redpanda_console/tasks/configure-deb-repository.yml
+++ b/roles/redpanda_console/tasks/configure-deb-repository.yml
@@ -6,13 +6,12 @@
     rp_repo_signing_deb_actual: "{{ rp_repo_signing_deb }}"
     rp_repo_signing_src_deb_actual: "{{ rp_repo_signing_src_deb }}"
 
-# Import the Redpanda signing key only when the keyring is missing the key the
-# repository is actually signed with. This stays idempotent in steady state
-# (a no-op once the key is present) while still performing the one-time cutover
-# when migrating an existing host onto a new key (e.g. the dl.redpanda.com ->
-# Artifact Registry migration) or on any future key rotation. The required
-# fingerprint is derived from whatever key the configured URL currently serves,
-# so this never needs revisiting when the signing key changes.
+# Refresh the keyring whenever it differs from the key material the repository
+# URL currently serves. The comparison is over the WHOLE dearmored keyring, not
+# a single fingerprint: rotation bundles (old+new keys published together),
+# refreshed subkeys, and extended expirations all change the bytes and trigger
+# an atomic replace, while steady state stays a no-op. (A fingerprint-presence
+# gate would skip exactly the rotation events this mechanism exists for.)
 - name: Fetch the current Redpanda DEB signing key
   ansible.builtin.get_url:
     url: "{{ rp_key_deb_actual }}"
@@ -23,33 +22,30 @@
     http_proxy: "{{ https_proxy_value | default('') }}"
   changed_when: false
 
-- name: Determine the signing key fingerprint we require
-  ansible.builtin.shell: >-
-    set -o pipefail;
-    gpg --show-keys --with-colons /tmp/redpanda-deb-signing.key | awk -F: '/^fpr:/{print $10; exit}'
-  args:
-    executable: /bin/bash
-  register: rp_want_deb_key_fpr
+- name: Dearmor the fetched signing key for comparison
+  ansible.builtin.command: gpg --dearmor --yes -o /tmp/redpanda-deb-signing.dearmored /tmp/redpanda-deb-signing.key
   changed_when: false
 
-- name: Read the fingerprints already present in the Redpanda keyring
-  ansible.builtin.shell: >-
-    set -o pipefail;
-    gpg --no-default-keyring --keyring "{{ rp_key_path_deb_actual }}" --list-keys --with-colons 2>/dev/null
-    | awk -F: '/^fpr:/{print $10}'
-  args:
-    executable: /bin/bash
-  register: rp_have_deb_key_fprs
+- name: Check whether the installed keyring matches the served key material
+  ansible.builtin.command: cmp -s /tmp/redpanda-deb-signing.dearmored "{{ rp_key_path_deb_actual }}"
+  register: rp_deb_keyring_cmp
   changed_when: false
   failed_when: false
 
-- name: Import/refresh the Redpanda signing key when it is missing (migration / rotation)
+- name: Install/refresh the Redpanda keyring (migration / rotation)
   become: true
-  ansible.builtin.command: gpg --dearmor --yes -o "{{ rp_key_path_deb_actual }}" /tmp/redpanda-deb-signing.key
-  when: rp_want_deb_key_fpr.stdout not in (rp_have_deb_key_fprs.stdout_lines | default([]))
+  ansible.builtin.copy:
+    src: /tmp/redpanda-deb-signing.dearmored
+    dest: "{{ rp_key_path_deb_actual }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0644'
+  when: rp_deb_keyring_cmp.rc != 0
 
-# `gpg --dearmor -o` creates a fresh keyring 0600 root; apt verifies signed-by keyrings as the
-# _apt user, which then can't read it (NO_PUBKEY). Force it world-readable like a public key file.
+# apt verifies signed-by keyrings as the _apt user; a pre-existing root-only (0600)
+# keyring fails verification (NO_PUBKEY) even when its contents are correct, so
+# force it world-readable like a public key file regardless of who created it.
 - name: Ensure the Redpanda keyring is world-readable for apt verification
   become: true
   ansible.builtin.file:

--- a/roles/redpanda_console/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_console/tasks/configure-rpm-repository.yml
@@ -13,7 +13,7 @@
     description: "{{ repo_name_prefix }}"
     baseurl: "{{ rp_standard_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -28,7 +28,7 @@
     description: "{{ repo_name_prefix }}-noarch"
     baseurl: "{{ rp_noarch_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -43,7 +43,7 @@
     description: "{{ repo_name_prefix }}-source"
     baseurl: "{{ rp_source_rpm_actual }}"
     gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: false
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'

--- a/roles/redpanda_console/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_console/tasks/configure-rpm-repository.yml
@@ -2,6 +2,7 @@
 - name: Set Redpanda RPM and GPG Key details
   ansible.builtin.set_fact:
     rp_key_rpm_actual: "{{ rp_key_rpm }}"
+    rp_key_rpm_metadata_actual: "{{ rp_key_rpm_metadata }}"
     rp_standard_rpm_actual: "{{ rp_standard_rpm }}"
     rp_noarch_rpm_actual: "{{ rp_noarch_rpm }}"
     rp_source_rpm_actual: "{{ rp_source_rpm }}"
@@ -12,8 +13,12 @@
     name: "{{ repo_name_prefix }}"
     description: "{{ repo_name_prefix }}"
     baseurl: "{{ rp_standard_rpm_actual }}"
-    gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: false
+    # package payloads are signed by Redpanda; repo metadata is signed by the
+    # Artifact Registry repository-signer key — both keys are needed
+    gpgkey:
+      - "{{ rp_key_rpm_actual }}"
+      - "{{ rp_key_rpm_metadata_actual }}"
+    repo_gpgcheck: true
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -27,8 +32,12 @@
     name: "{{ repo_name_prefix }}-noarch"
     description: "{{ repo_name_prefix }}-noarch"
     baseurl: "{{ rp_noarch_rpm_actual }}"
-    gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: false
+    # package payloads are signed by Redpanda; repo metadata is signed by the
+    # Artifact Registry repository-signer key — both keys are needed
+    gpgkey:
+      - "{{ rp_key_rpm_actual }}"
+      - "{{ rp_key_rpm_metadata_actual }}"
+    repo_gpgcheck: true
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -42,8 +51,12 @@
     name: "{{ repo_name_prefix }}-source"
     description: "{{ repo_name_prefix }}-source"
     baseurl: "{{ rp_source_rpm_actual }}"
-    gpgkey: "{{ rp_key_rpm_actual }}"
-    repo_gpgcheck: false
+    # package payloads are signed by Redpanda; repo metadata is signed by the
+    # Artifact Registry repository-signer key — both keys are needed
+    gpgkey:
+      - "{{ rp_key_rpm_actual }}"
+      - "{{ rp_key_rpm_metadata_actual }}"
+    repo_gpgcheck: true
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -57,11 +70,17 @@
     https_proxy: "{{ rpm_proxy | default('') }}"
   ansible.builtin.rpm_key:
     state: present
-    key: "{{ rp_key_rpm_actual }}"
+    key: "{{ item }}"
+  loop:
+    - "{{ rp_key_rpm_actual }}"
+    - "{{ rp_key_rpm_metadata_actual }}"
   when: https_proxy_value is defined and https_proxy_value | length > 0
 
 - name: Install GPG key
   ansible.builtin.rpm_key:
     state: present
-    key: "{{ rp_key_rpm_actual }}"
+    key: "{{ item }}"
+  loop:
+    - "{{ rp_key_rpm_actual }}"
+    - "{{ rp_key_rpm_metadata_actual }}"
   when: (https_proxy_value is not defined or https_proxy_value | length == 0)

--- a/roles/redpanda_console/tasks/configure-rpm-repository.yml
+++ b/roles/redpanda_console/tasks/configure-rpm-repository.yml
@@ -1,4 +1,19 @@
 ---
+# dnf5's repo-metadata verifier rejects the Artifact Registry repomd.xml signature
+# (a critical hashed Issuer subpacket gpg/dnf4 accept but dnf5 does not), so
+# repo_gpgcheck must be off on dnf5 hosts and stays on everywhere else. Package
+# payloads are still verified via gpgcheck=1 regardless. Google documents
+# repo_gpgcheck=0 as the AR client config:
+# https://cloud.google.com/artifact-registry/docs/os-packages/rpm/configure
+- name: Detect dnf5 (Artifact Registry repomd signatures fail its verifier)
+  ansible.builtin.stat:
+    path: /usr/bin/dnf5
+  register: rp_dnf5_bin
+
+- name: Set repo_gpgcheck (off on dnf5, on elsewhere)
+  ansible.builtin.set_fact:
+    rp_repo_gpgcheck: "{{ not rp_dnf5_bin.stat.exists }}"
+
 - name: Set Redpanda RPM and GPG Key details
   ansible.builtin.set_fact:
     rp_key_rpm_actual: "{{ rp_key_rpm }}"
@@ -18,7 +33,7 @@
     gpgkey:
       - "{{ rp_key_rpm_actual }}"
       - "{{ rp_key_rpm_metadata_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: "{{ rp_repo_gpgcheck }}"
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -37,7 +52,7 @@
     gpgkey:
       - "{{ rp_key_rpm_actual }}"
       - "{{ rp_key_rpm_metadata_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: "{{ rp_repo_gpgcheck }}"
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'
@@ -56,7 +71,7 @@
     gpgkey:
       - "{{ rp_key_rpm_actual }}"
       - "{{ rp_key_rpm_metadata_actual }}"
-    repo_gpgcheck: true
+    repo_gpgcheck: "{{ rp_repo_gpgcheck }}"
     gpgcheck: true
     enabled: true
     sslcacert: '/etc/pki/tls/certs/ca-bundle.crt'


### PR DESCRIPTION
Builds on **#145** (dl.redpanda.com → Artifact Registry migration) — that commit is included here as the base, and this branch adds the apt signing-key handling needed for the migration to work on **upgrades and fresh installs**. The maintainers can either merge this in place of #145 or land #145 first and rebase this to just the fix.

## Why the added fix is needed
Validating the migration against the last released collection surfaced two failures the original `creates:`-guarded key import left behind:

1. **Upgrade → `NO_PUBKEY`.** The AR repo is signed by a different key than dl.redpanda.com. On a host built by a prior release the keyring already existed, so the new key was never imported; `apt-get update` then fails `NO_PUBKEY C0BA5CE6DC6315A3` on every upgraded broker. Replaced the `creates:` guard with a fingerprint check — (re)import only when the keyring is missing the key the repo is actually signed with (covers fresh install, the dl→AR migration, and future key rotations).
2. **Fresh install → `NO_PUBKEY`.** `gpg --dearmor -o` creates a new keyring `0600 root`; apt verifies `signed-by` keyrings as the `_apt` user, which then can't read it. Force the keyring world-readable (`0644`). Surfaced by the console install — the first fresh AR install on a verifying path.

Applied to both `redpanda_broker` and `redpanda_console`.

## Validation
Both failures reproduced and confirmed fixed via a collection-upgrade harness (install last-released collection → re-converge with this branch, pinned RP version, 500-record data-survival + per-node key/repo/version/health assertions), green on AWS (`allow_unauthenticated=false`, real key verification) and GCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
