### PR TITLE
xfs: Disable rmapbt

### DIFF
--- a/roles/system_setup/tasks/prepare-data-dir.yml
+++ b/roles/system_setup/tasks/prepare-data-dir.yml
@@ -69,6 +69,7 @@
       community.general.filesystem:
         fstype: xfs
         dev: '{{ nvme_devices_for_raid[0] }}'
+        opts: "-m rmapbt=0"
       when: nvme_devices_for_raid|length == 1
     # Reference the volume by filesystem UUID rather than the kernel device
     # path: NVMe device names are assigned in discovery order and are not stable
@@ -113,6 +114,7 @@
       community.general.filesystem:
         fstype: xfs
         dev: /dev/md0
+        opts: "-m rmapbt=0"
       when: nvme_devices_for_raid|length > 1
     # Mount the array by filesystem UUID. The md device name is also assigned at
     # assembly time and is not guaranteed stable, so the UUID of the filesystem


### PR DESCRIPTION
This option has been found to cause scalability issues on larger nodes. Disable it, we don't make use of it otherwise and it has been turned on by default on newer kernels.

mkfs has supported this option for quite a while now (all the way back to ubu 18 and RHEL 8) so we just set it unconditionally.

Ref CORE-17178 CORE-2946